### PR TITLE
Allow installing ubisoft games that includes compressed files

### DIFF
--- a/legendary/core.py
+++ b/legendary/core.py
@@ -1566,14 +1566,7 @@ class LegendaryCore:
                                  f'available. If you previously deleted the game folder without uninstalling, run '
                                  f'"legendary uninstall -y {game.app_name}" first.')
 
-        # check if the game actually ships the files or just a uplay installer + packed game files
         uplay_required = False
-        executables = [f for f in analysis.manifest_comparison.added if
-                       f.lower().endswith('.exe') and not f.startswith('Installer/')]
-        if not updating and not any('uplay' not in e.lower() for e in executables) and \
-                any('uplay' in e.lower() for e in executables):
-            uplay_required = True
-            results.failures.add('This game requires installation via Uplay and does not ship executable game files.')
 
         if install.prereq_info:
             prereq_path = install.prereq_info['path'].lower()


### PR DESCRIPTION
This would prevent the error that happens in Heroic when trying to install Watch Dogs 2.

The game does not include executable files but it actually includes compressed files. Then, when launched the first time, it will prompt the user to install the game and it will use the compressed data to ""download"" the game.

From my tests, it's not re-downloading the game, it's decompressing and updating it.