### PR TITLE
Make JSON decoding in LockedJSONData fallible

### DIFF
--- a/legendary/lfs/utils.py
+++ b/legendary/lfs/utils.py
@@ -171,8 +171,11 @@ class LockedJSONData(FileLock):
 
         if os.path.exists(self._file_path):
             with open(self._file_path, 'r', encoding='utf-8') as f:
-                self._data = json.load(f)
-                self._initial_data = self._data
+                try:
+                    self._data = json.load(f)
+                    self._initial_data = self._data
+                except json.JSONDecodeError:
+                    pass
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):


### PR DESCRIPTION
I'm not quite sure *why* this happens yet, but it seems that some users might end up with an *empty* (not non-existent) user data file (`user.json`). The LockedJSONData class tries to automatically decode this file on entry of its `with` block, leading to an exception being raised.
We can just treat the file like it doesn't exist in this case