### PR TITLE
Reuse chunks from the same download if duplicated

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,8 @@ optional arguments:
   --exclude <prefix>    Exclude files starting with <prefix> (case
                         insensitive)
   --install-tag <tag>   Only download files with the specified install tag
+  --read-files          Read duplicated parts from already saved files, do not
+                        keep them in RAM
   --enable-reordering   Enable reordering optimization to reduce RAM
                         requirements during download (may have adverse results
                         for some titles)
@@ -670,6 +672,8 @@ log_level = debug
 max_memory = 2048
 ; maximum number of worker processes when downloading (fewer workers will be slower, but also use less system resources)
 max_workers = 8
+; Enables reading duplicated data from files during download (decreases RAM usage but increases disk I/O)
+read_files = false
 ; default install directory
 install_dir = /mnt/tank/games
 ; locale override, must be in RFC 1766 format (e.g. "en-US")

--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -971,6 +971,7 @@ class LegendaryCLI:
                                                           file_prefix_filter=args.file_prefix,
                                                           file_exclude_filter=args.file_exclude_prefix,
                                                           file_install_tag=args.install_tag,
+                                                          read_files=args.read_files,
                                                           dl_optimizations=args.order_opt,
                                                           dl_timeout=args.dl_timeout,
                                                           repair=args.repair_mode,
@@ -2768,6 +2769,8 @@ def main():
                                 type=str, help='Exclude files starting with <prefix> (case insensitive)')
     install_parser.add_argument('--install-tag', dest='install_tag', action='append', metavar='<tag>',
                                 type=str, help='Only download files with the specified install tag')
+    install_parser.add_argument('--read-files', dest='read_files', action='store_true',
+                                help='Read duplicated parts from already saved files, do not keep them in memory')
     install_parser.add_argument('--enable-reordering', dest='order_opt', action='store_true',
                                 help='Enable reordering optimization to reduce RAM requirements '
                                      'during download (may have adverse results for some titles)')


### PR DESCRIPTION
Drastically decrease memory usage by reusing chunk parts from already downloaded files.
See https://github.com/derrod/legendary/issues/17

Usually we do not need even 1Gb of shared memory with this patch.

This is the same approach and roughly the same code as we have for reusing chunks of old game files on update couple lines above.

This is a copy of PR against upstream https://github.com/derrod/legendary/pull/683 to speed up delivery of solution for Heroic users

Should help with issues like https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/2732, https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4054, https://github.com/derrod/legendary/issues/149,
https://github.com/derrod/legendary/issues/151

Personally I was able to download "The Talos Principle 2" with less than 300 Mb of RAM cache usage all the time. Before this patch, about 12Gb was required.

Testing and reviews welcome.

