### PR TITLE
fix: unset old_manifest for all types of repair

### DIFF
--- a/legendary/core.py
+++ b/legendary/core.py
@@ -1457,7 +1457,7 @@ class LegendaryCore:
             if not repair_use_latest and old_manifest:
                 # use installed manifest for repairs instead of updating
                 new_manifest = old_manifest
-                old_manifest = None
+            old_manifest = None
 
             filename = clean_filename(f'{game.app_name}.repair')
             resume_file = os.path.join(self.lgd.get_tmp_path(), filename)


### PR DESCRIPTION
This fixes an error like this, when used with `--repair-and-update` flag

```
[Core] INFO: Trying to re-use existing login session...
[cli] INFO: Game has not been verified yet.
[cli] INFO: Loading installed manifest for "82cdbdf05c61474d89c4f9e8a8bf0ea4"
[cli] INFO: Verifying "DNF Duel" version "1.8.1-0"
[cli] ERROR: File is missing: "Engine/Content/SlateDebug/Fonts/LastResort.tps"
Verification progress: 24/27 (1.6%) [0.0 MiB/s]
=> Verifying large file "RED/Content/Paks/RED-WindowsNoEditor.pak": 100% (9305.2/9305.2 MiB) [2248.7 MiB/s]
Verification progress: 27/27 (100.0%) [2239.5 MiB/s]
[cli] ERROR: Verification failed, 0 file(s) corrupted, 1 file(s) are missing.
[cli] INFO: Preparing download for "DNF Duel" (82cdbdf05c61474d89c4f9e8a8bf0ea4)...
[Core] INFO: Parsing game manifest...
[Core] INFO: Install path: /home/user/Games/Heroic/DnfDuel
[Core] INFO: Selected CDN: download.epicgames.com (https)
[DLM] INFO: Found previously interrupted download. Download will be resumed if possible.
[DLM] INFO: Skipping 26 files based on resume data.
[cli] INFO: Download size is 0, the game is either already up to date or has not changed. Exiting...
```