### PR TITLE
feat!: support multiple namespaces for the game

### DIFF
--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -921,7 +921,8 @@ class LegendaryCLI:
             exit(1)
         
         if args.namespace and not args.namespace in game.namespaces:
-            logger.error("Unknown namespace")
+            available_namespaces = '\n'.join(list(game.namespaces.keys()))
+            logger.error("Unknown namespace\n" + available_namespaces)
             exit(1)
 
         if game.is_dlc:
@@ -1009,7 +1010,7 @@ class LegendaryCLI:
         # todo use status queue to print progress from CLI
         # This has become a little ridiculous hasn't it?
         dlm, analysis, igame = self.core.prepare_download(game=game, base_game=base_game, base_path=args.base_path,
-                                                          force=args.force, max_shm=args.shared_memory, namespace=args.namespace,
+                                                          force=args.force, max_shm=args.shared_memory,
                                                           max_workers=args.max_workers, game_folder=args.game_folder,
                                                           disable_patching=args.disable_patching,
                                                           override_manifest=args.override_manifest,
@@ -1028,6 +1029,7 @@ class LegendaryCLI:
                                                           override_delta_manifest=args.override_delta_manifest,
                                                           preferred_cdn=args.preferred_cdn,
                                                           disable_https=args.disable_https,
+                                                          namespace=args.namespace,
                                                           bind_ip=args.bind_ip)
 
         # game is either up-to-date or hasn't changed, so we have nothing to do

--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -284,7 +284,7 @@ class LegendaryCLI:
         versions = dict()
         for game in games:
             try:
-                versions[game.app_name] = self.core.get_asset(game.app_name, platform=game.platform).build_version
+                versions[game.app_name] = self.core.get_asset(game.app_name, platform=game.platform, namespace=game.namespace).build_version
             except ValueError:
                 logger.warning(f'Metadata for "{game.app_name}" is missing, the game may have been removed from '
                                f'your account or not be in legendary\'s database yet, try rerunning the command '

--- a/legendary/core.py
+++ b/legendary/core.py
@@ -825,7 +825,7 @@ class LegendaryCore:
             f'-epicsandboxid={namespace}'
         ])
 
-        if sidecar := game.sidecars.get(namespace):
+        if sidecar := game.sidecars and game.sidecars.get(namespace):
             if deployment_id := sidecar.config.get('deploymentId', None):
                 params.egl_parameters.append(f'-epicdeploymentid={deployment_id}')
 

--- a/legendary/core.py
+++ b/legendary/core.py
@@ -375,12 +375,12 @@ class LegendaryCore:
                 self.lgd.library_items = lib
         return self.lgd.library_items
 
-    def get_asset(self, app_name, platform='Windows', update=False) -> GameAsset:
+    def get_asset(self, app_name, platform='Windows', update=False, namespace=None) -> GameAsset:
         if update or platform not in self.lgd.assets:
             self.get_assets(update_assets=True, platform=platform)
 
         try:
-            return next(i for i in self.lgd.assets[platform] if i.app_name == app_name)
+            return next(i for i in self.lgd.assets[platform] if i.app_name == app_name and (namespace is None or i.namespace == namespace))
         except StopIteration:
             raise ValueError
 

--- a/legendary/lfs/lgndry.py
+++ b/legendary/lfs/lgndry.py
@@ -37,6 +37,8 @@ class LGDLFS:
         self._user_data = None
         # EGS entitlements
         self._entitlements = None
+        # EGS library items
+        self._library_items = None
         # EGS asset data
         self._assets = None
         # EGS metadata
@@ -216,6 +218,25 @@ class LGDLFS:
         self._assets = assets
         json.dump({platform: [a.__dict__ for a in assets] for platform, assets in self._assets.items()},
                   open(os.path.join(self.path, 'assets.json'), 'w'),
+                  indent=2, sort_keys=True)
+        
+    @property
+    def library_items(self):
+        if self._library_items is not None:
+            return self._library_items
+        try:
+            self._library_items = json.load( open(os.path.join(self.path, 'library_items.json')))
+            return self._library_items
+        except Exception as e:
+            self.log.debug(f'Failed to load library items data: {e!r}')
+            return None
+    
+    @library_items.setter
+    def library_items(self, library_items):
+        if library_items is None:
+            raise ValueError("Library items is none!")
+        self._library_items = library_items
+        json.dump(library_items, open(os.path.join(self.path, 'library_items.json'), 'w'),
                   indent=2, sort_keys=True)
 
     def _get_manifest_filename(self, app_name, version, platform=None):

--- a/legendary/models/game.py
+++ b/legendary/models/game.py
@@ -167,8 +167,11 @@ class Game:
             app_title=json.get('app_title', ''),
         )
         tmp.metadata = json.get('metadata', dict())
-        if 'asset_infos' in json:
-            tmp.asset_infos = {k: [GameAsset.from_json(a) for a in v] if type(v) is list else [GameAsset.from_json(v)] for k, v in json['asset_infos'].items()}
+        if 'asset_infos_v2' in json:
+            tmp.asset_infos = {k: [GameAsset.from_json(a) for a in v] for k, v in json['asset_infos_v2'].items()}
+        elif 'asset_infos' in json:
+            # Migrate from one asset per platform to multiple
+            tmp.asset_infos = {k: [GameAsset.from_json(v)] for k, v in json['asset_infos'].items()}
         else:
             # Migrate old asset_info to new asset_infos
             tmp.asset_infos['Windows'] = [GameAsset.from_json(json.get('asset_info', dict()))]
@@ -190,7 +193,7 @@ class Game:
         """This is just here so asset_infos gets turned into a dict as well"""
         assets_dictified = {k: [a.__dict__ for a in v] for k, v in self.asset_infos.items()}
         sidecars_dictified = {k: s.__dict__ for k,s in self.sidecars.items()} if self.sidecars else None
-        return dict(metadata=self.metadata, asset_infos=assets_dictified, app_name=self.app_name,
+        return dict(metadata=self.metadata, asset_infos_v2=assets_dictified, app_name=self.app_name,
                     app_title=self.app_title, base_urls=self.base_urls, sidecars=sidecars_dictified,
                     namespaces=self.namespaces)
 


### PR DESCRIPTION
This is a breaking change that allows games to contain more than one asset per platform - meaning multiple sandboxes aka namespaces.

This involves breaking changes to how metadata.json is stored, as well as additional fields to installed game classes. 
Sidecar configs were also separated into per-namespace maps.

Changes to metadata mean older versions of legendary will probably fail to read those files. I can try to make this as much backwards compatible as possible if desired.

Additional remarks:
- info and install commands support --namespace arguments now
- info output was slightly changed to incorporate multiple assets per platform
  - latest_version and manifest keys correspond to desired --namespace, by default its first public asset found
  - namespaces key is an array of available namespaces, their details and times when given license was obtained by user
  - platform_versions is now a `{platform: [...assets]}` object, instead of just versions