### PR TITLE
Workflow-related changes

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [
           'ubuntu-22.04', 'ubuntu-22.04-arm',
-          'windows-latest',
+          'windows-latest', 'windows-11-arm',
           'macos-13', 'macos-14'
         ]
       fail-fast: false

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,7 +11,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'ubuntu-22.04-arm', 'windows-latest', 'macos-13', 'macos-14']
+        os: [
+          'ubuntu-22.04', 'ubuntu-22.04-arm',
+          'windows-latest',
+          'macos-13', 'macos-14'
+        ]
       fail-fast: false
       max-parallel: 3
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Set strip option on non-Windows
       id: strip
-      run: echo ::set-output name=option::--strip
+      run: echo "option=--strip" >> $GITHUB_OUTPUT
       if: runner.os != 'Windows'
 
     - name: Build

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,7 +24,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.11'
 
     - name: Legendary dependencies and build tools
       run: pip3 install --upgrade


### PR DESCRIPTION
- Updates the x64 Linux runner to Ubuntu 22.04 (20.04 is no longer available)
- Adds a Windows 11 ARM runner
- Use `GITHUB_OUTPUT` instead of `::set-output` as per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/