### PR TITLE
Fix download issue for games with large number of savefiles and improve performance

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -31,6 +31,7 @@ jobs:
         setuptools
         pyinstaller
         requests
+        requests_futures
         filelock
 
     - name: Optional dependencies (WebView)

--- a/legendary/api/egs.py
+++ b/legendary/api/egs.py
@@ -2,10 +2,13 @@
 # coding: utf-8
 
 import urllib.parse
+from urllib3.util import Retry
 
 import requests
 import requests.adapters
 import logging
+
+from requests_futures.sessions import FuturesSession
 
 from requests.auth import HTTPBasicAuth
 
@@ -43,8 +46,21 @@ class EPCAPI:
         # increase maximum pool size for multithreaded metadata requests
         self.session.mount('https://', requests.adapters.HTTPAdapter(pool_maxsize=16))
 
+        retries = Retry(
+            total=3,
+            backoff_factor=0.1,
+            status_forcelist=[500, 501, 502, 503, 504],
+            allowed_methods={'GET'}
+        )
+
         self.unauth_session = requests.session()
         self.unauth_session.headers['User-Agent'] = self._user_agent
+
+        self.unauth_session.mount('https://', requests.adapters.HTTPAdapter(pool_connections=16, pool_maxsize=16, max_retries=retries))
+
+        self.unauth_future_session = FuturesSession(session=self.unauth_session,max_workers=16)
+        self.unauth_future_session.headers['User-Agent'] = self._user_agent
+
 
         self._oauth_basic = HTTPBasicAuth(self._user_basic, self._pw_basic)
 
@@ -68,6 +84,7 @@ class EPCAPI:
             self._store_user_agent = f'EpicGamesLauncher/{version}'
             self.session.headers['User-Agent'] = self._user_agent
             self.unauth_session.headers['User-Agent'] = self._user_agent
+            self.unauth_future_session.headers['User-Agent'] = self._user_agent
         # update label
         if label := egs_params['label']:
             self._label = label

--- a/legendary/core.py
+++ b/legendary/core.py
@@ -1086,10 +1086,7 @@ class LegendaryCore:
             m = self.load_manifest(r.content)
 
             # download chunks required for extraction
-            chunkPaths = []
-            for chunk in m.chunk_data_list.elements:
-                chunkPaths.append(chunk.path)
-
+            chunkPaths = list(chunk.path for chunk in m.chunk_data_list.elements)
             chunkSaves = self.egs.get_user_cloud_saves(app_name=app_name, filenames=chunkPaths, manifests=False)
             chunkFiles = chunkSaves["files"]
 

--- a/legendary/core.py
+++ b/legendary/core.py
@@ -1043,11 +1043,9 @@ class LegendaryCore:
             os.makedirs(save_path)
 
         _save_dir = save_dir
-        savegames = self.egs.get_user_cloud_saves(app_name=app_name)
-        files = savegames['files']
+        manifests = self.egs.get_user_cloud_saves(app_name=app_name,manifests=True)
+        files = manifests["files"]
         for fname, f in files.items():
-            if '.manifest' not in fname:
-                continue
             f_parts = fname.split('/')
 
             if manifest_name and f_parts[4] != manifest_name:
@@ -1088,17 +1086,29 @@ class LegendaryCore:
             m = self.load_manifest(r.content)
 
             # download chunks required for extraction
-            chunks = dict()
+            chunkPaths = []
             for chunk in m.chunk_data_list.elements:
-                cpath_p = fname.split('/', 3)[:3]
-                cpath_p.append(chunk.path)
-                cpath = '/'.join(cpath_p)
-                if cpath not in files:
-                    self.log.warning(f'Chunk {cpath} not in file list, save data may be incomplete!')
-                    continue
+                chunkPaths.append(chunk.path)
 
-                self.log.debug(f'Downloading chunk "{cpath}"')
-                r = self.egs.unauth_session.get(files[cpath]['readLink'])
+            chunkSaves = self.egs.get_user_cloud_saves(app_name=app_name, filenames=chunkPaths, manifests=False)
+            chunkFiles = chunkSaves["files"]
+
+            if len(chunkFiles) != len(chunkPaths):
+                self.log.warning(f'Expected {len(chunkPaths)} chunks, but only found {len(chunkFiles)}! Save may be incomplete.')
+                continue
+
+            chunkLinks = [chunkFiles[c]['readLink'] for c in chunkFiles]
+            self.log.info(f'Downloading {len(chunkLinks)} chunks...')
+
+            def log_download(r, *args, **kwargs):
+                self.log.debug(f'Downloaded chunk {'/'.join(urlparse(r.url).path.split('/')[5:])} successfully.')
+
+            # map chunkLinks to self.egs.unauth_future_session.get
+            futures = [self.egs.unauth_future_session.get(link, hooks={'response': log_download}) for link in chunkLinks]
+
+            chunks = dict()
+            for future in futures:
+                r = future.result()
                 if r.status_code != 200:
                     self.log.error(f'Download failed, status code: {r.status_code}')
                     break

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests<3.0
+requests_futures
 filelock

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     ),
     install_requires=[
         'requests<3.0',
+        'requests_futures',
         'setuptools',
         'wheel',
         'filelock'


### PR DESCRIPTION
While testing with a game that has ~650 savefiles, I noticed that Legendary wasn't downloading any data — the download process completed instantly without actually retrieving any files.

### Root Cause
Upon investigation, I discovered that the Epic Games Store (EGS) API limits the number of files returned in the metadata JSON to **1000 entries**. For games with many files, such as save-heavy ones, essential files like the manifest chunks were missing from the response due to this limit.

### Fix
To resolve this, I:
- Modified the download logic to **request manifest data separately**, bypassing the 1000-file limitation.
- Then used the manifest contents to **selectively request only the necessary chunks** from the API.  
  - In my test case, this resulted in ~1600 chunk files to be downloaded.

### Enhancements
To improve download performance and reliability:
- **Implemented parallel chunk downloads**, significantly reducing overall download time (for my example):
  - **Before:** 11 minutes 40 seconds  
  - **After:** 1 minute 6 seconds
- **Added a retry mechanism** for failed chunk requests, as parallel requests occasionally encounter transient errors.

https://github.com/derrod/legendary/pull/709

Possible fix https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3708
