### PR TITLE
[Fix] Ignore leading/trailing whitespace in cloud save filter list items

### DIFF
--- a/legendary/core.py
+++ b/legendary/core.py
@@ -1011,9 +1011,9 @@ class LegendaryCore:
         if not disable_filtering:
             # get file inclusion and exclusion filters if they exist
             if (_include := custom_attr.get('CloudIncludeList', {}).get('value', None)) is not None:
-                include_f = _include.split(',')
+                include_f = list(f.strip() for f in _include.split(','))
             if (_exclude := custom_attr.get('CloudExcludeList', {}).get('value', None)) is not None:
-                exclude_f = _exclude.split(',')
+                exclude_f = list(f.strip() for f in _exclude.split(','))
 
         if not save_path and not save_path_mac:
             raise ValueError('Game does not support cloud saves')


### PR DESCRIPTION
Some games define cloud save inclusion/exclusion lists like this:
```json
"CloudIncludeList": {
  "type": "STRING",
  "value": "savegames/,config-cloud.cfg,keybindings-*.txt"
},
```
(example is "Dungeons 3"), others instead use
```json
"CloudIncludeList": {
  "type": "STRING",
  "value": "Saves/, MPSaves/"
},
```
("Galactic Civilizations III")

I have not confirmed this, but these differing formats suggests the EGL simply ignores leading/trailing whitespace in filter entries. Let's do that as well