### PR TITLE
Support signed chunk download URLs

### DIFF
--- a/legendary/core.py
+++ b/legendary/core.py
@@ -1262,6 +1262,7 @@ class LegendaryCore:
             raise ValueError('Manifest response has more than one element!')
 
         manifest_hash = m_api_r['elements'][0]['hash']
+        manifest_use_signed_url: bool = m_api_r['elements'][0]['useSignedUrl']
         base_urls = []
         manifest_urls = []
         for manifest in m_api_r['elements'][0]['manifests']:
@@ -1275,10 +1276,10 @@ class LegendaryCore:
             else:
                 manifest_urls.append(manifest['uri'])
 
-        return manifest_urls, base_urls, manifest_hash
+        return manifest_urls, base_urls, manifest_hash, manifest_use_signed_url
 
     def get_cdn_manifest(self, game, platform='Windows', disable_https=False):
-        manifest_urls, base_urls, manifest_hash = self.get_cdn_urls(game, platform)
+        manifest_urls, base_urls, manifest_hash, use_signed_url = self.get_cdn_urls(game, platform)
         if not manifest_urls:
             raise ValueError('No manifest URLs returned by API')
 
@@ -1306,7 +1307,7 @@ class LegendaryCore:
         if sha1(manifest_bytes).hexdigest() != manifest_hash:
             raise ValueError('Manifest sha hash mismatch!')
 
-        return manifest_bytes, base_urls
+        return manifest_bytes, base_urls, use_signed_url
 
     def get_uri_manifest(self, uri):
         if uri.startswith('http'):
@@ -1341,7 +1342,8 @@ class LegendaryCore:
                          repair: bool = False, repair_use_latest: bool = False,
                          disable_delta: bool = False, override_delta_manifest: str = '',
                          egl_guid: str = '', preferred_cdn: str = None,
-                         disable_https: bool = False, bind_ip: str = None) -> tuple[DLManager, AnalysisResult, InstalledGame]:
+                         disable_https: bool = False, bind_ip: str = None, always_use_signed_urls: bool = False
+                         ) -> tuple[DLManager, AnalysisResult, InstalledGame]:
         # load old manifest
         old_manifest = None
 
@@ -1369,11 +1371,13 @@ class LegendaryCore:
         if override_manifest:
             self.log.info(f'Overriding manifest with "{override_manifest}"')
             new_manifest_data, _base_urls = self.get_uri_manifest(override_manifest)
+            # FIXME: Populate `use_signed_urls`
+            use_signed_urls = False
             # if override manifest has a base URL use that instead
             if _base_urls:
                 base_urls = _base_urls
         else:
-            new_manifest_data, base_urls = self.get_cdn_manifest(game, platform, disable_https=disable_https)
+            new_manifest_data, base_urls, use_signed_urls = self.get_cdn_manifest(game, platform, disable_https=disable_https)
             # overwrite base urls in metadata with current ones to avoid using old/dead CDNs
             game.base_urls = base_urls
             # save base urls to game metadata
@@ -1509,7 +1513,12 @@ class LegendaryCore:
         if not max_workers:
             max_workers = self.lgd.config.getint('Legendary', 'max_workers', fallback=0)
 
-        dlm = DLManager(install_path, base_url, resume_file=resume_file, status_q=status_q,
+        if always_use_signed_urls:
+            use_signed_urls = True
+
+        asset = self.get_asset(game.app_name, platform)
+        dlm = DLManager(install_path, base_url, use_signed_urls, asset,
+                        resume_file=resume_file, status_q=status_q,
                         max_shared_memory=max_shm * 1024 * 1024, max_workers=max_workers,
                         dl_timeout=dl_timeout, bind_ip=bind_ip)
 
@@ -1528,7 +1537,8 @@ class LegendaryCore:
             if read_files:
                 raise
             self.log.warning('Memory error encountered, retrying with file read enabled...')
-            dlm = DLManager(install_path, base_url, resume_file=resume_file, status_q=status_q,
+            dlm = DLManager(install_path, base_url, use_signed_urls, asset,
+                        resume_file=resume_file, status_q=status_q,
                         max_shared_memory=max_shm * 1024 * 1024, max_workers=max_workers,
                         dl_timeout=dl_timeout, bind_ip=bind_ip)
             anlres = dlm.run_analysis(manifest=new_manifest, **analysis_kwargs, read_files=True)
@@ -1566,7 +1576,7 @@ class LegendaryCore:
                               can_run_offline=offline == 'true', requires_ot=ot == 'true',
                               is_dlc=base_game is not None, install_size=anlres.install_size,
                               egl_guid=egl_guid, install_tags=file_install_tag,
-                              platform=platform, uninstaller=uninstaller)
+                              platform=platform, uninstaller=uninstaller, use_signed_url=use_signed_urls)
 
         return dlm, anlres, igame
 
@@ -1781,9 +1791,11 @@ class LegendaryCore:
                 if not needs_verify:
                     self.log.debug(f'No in-progress installation found, assuming complete...')
 
+        # FIXME: Populate `use_signed_url`
+        use_signed_url = False
         if not manifest_data:
             self.log.info(f'Downloading latest manifest for "{game.app_name}"')
-            manifest_data, base_urls = self.get_cdn_manifest(game)
+            manifest_data, base_urls, use_signed_url = self.get_cdn_manifest(game)
             if not game.base_urls:
                 game.base_urls = base_urls
                 self.lgd.set_game_meta(game.app_name, game)
@@ -1809,7 +1821,7 @@ class LegendaryCore:
                               executable=new_manifest.meta.launch_exe, can_run_offline=offline == 'true',
                               launch_parameters=new_manifest.meta.launch_command, requires_ot=ot == 'true',
                               needs_verification=needs_verify, install_size=install_size, egl_guid=egl_guid,
-                              platform=platform)
+                              platform=platform, use_signed_url=use_signed_url)
 
         return new_manifest, igame
 
@@ -2060,7 +2072,7 @@ class LegendaryCore:
         if not self.logged_in:
             self.egs.start_session(client_credentials=True)
 
-        _manifest, base_urls = self.get_cdn_manifest(EOSOverlayApp)
+        _manifest, base_urls, use_signed_urls = self.get_cdn_manifest(EOSOverlayApp)
         manifest = self.load_manifest(_manifest)
 
         if igame := self.lgd.get_overlay_install_info():
@@ -2068,7 +2080,9 @@ class LegendaryCore:
         else:
             path = path or os.path.join(self.get_default_install_dir(), '.overlay')
 
-        dlm = DLManager(path, base_urls[0])
+        # TODO: Verify that we can call `get_asset` here
+        asset = self.get_asset(EOSOverlayApp.app_name)
+        dlm = DLManager(path, base_urls[0], use_signed_urls, asset)
         analysis_result = dlm.run_analysis(manifest=manifest)
 
         install_size = analysis_result.install_size
@@ -2117,7 +2131,7 @@ class LegendaryCore:
         if os.path.exists(path):
             raise FileExistsError(f'Bottle {bottle_name} already exists')
 
-        dlm = DLManager(path, base_url)
+        dlm = DLManager(path, base_url, False, GameAsset())
         analysis_result = dlm.run_analysis(manifest=manifest)
 
         install_size = analysis_result.install_size

--- a/legendary/core.py
+++ b/legendary/core.py
@@ -1341,7 +1341,7 @@ class LegendaryCore:
                          repair: bool = False, repair_use_latest: bool = False,
                          disable_delta: bool = False, override_delta_manifest: str = '',
                          egl_guid: str = '', preferred_cdn: str = None,
-                         disable_https: bool = False, bind_ip: str = None) -> (DLManager, AnalysisResult, ManifestMeta):
+                         disable_https: bool = False, bind_ip: str = None) -> tuple[DLManager, AnalysisResult, InstalledGame]:
         # load old manifest
         old_manifest = None
 

--- a/legendary/core.py
+++ b/legendary/core.py
@@ -2080,9 +2080,10 @@ class LegendaryCore:
         else:
             path = path or os.path.join(self.get_default_install_dir(), '.overlay')
 
-        # TODO: Verify that we can call `get_asset` here
-        asset = self.get_asset(EOSOverlayApp.app_name)
-        dlm = DLManager(path, base_urls[0], use_signed_urls, asset)
+        if use_signed_urls:
+            raise ValueError('EOS Overlay requiring signed URLs, not sure what to do here')
+
+        dlm = DLManager(path, base_urls[0], use_signed_urls, GameAsset())
         analysis_result = dlm.run_analysis(manifest=manifest)
 
         install_size = analysis_result.install_size

--- a/legendary/downloader/mp/manager.py
+++ b/legendary/downloader/mp/manager.py
@@ -44,14 +44,14 @@ class DLManager(Process):
         self.bind_ips = [] if not bind_ip else bind_ip.split(',')
 
         # Analysis stuff
-        self.analysis = None
-        self.tasks = deque()
-        self.chunks_to_dl = deque()
-        self.chunk_data_list = None
+        self.analysis: Optional[AnalysisResult] = None
+        self.tasks: deque[FileTask | ChunkTask] = deque()
+        self.chunks_to_dl: deque[int] = deque()
+        self.chunk_data_list: Optional[CDL] = None
 
         # shared memory stuff
         self.max_shared_memory = max_shared_memory  # 1 GiB by default
-        self.sms = deque()
+        self.sms: deque[SharedMemorySegment] = deque()
         self.shared_memory = None
 
         # Interval for log updates and pushing updates to the queue

--- a/legendary/downloader/mp/manager.py
+++ b/legendary/downloader/mp/manager.py
@@ -9,18 +9,22 @@ import time
 from collections import Counter, defaultdict, deque
 from logging.handlers import QueueHandler
 from multiprocessing import cpu_count, Process, Queue as MPQueue
+from multiprocessing.connection import Connection
 from multiprocessing.shared_memory import SharedMemory
 from queue import Empty
 from sys import exit
 from threading import Condition, Thread
+from time import sleep
 
 from legendary.downloader.mp.workers import DLWorker, FileWorker
 from legendary.models.downloading import *
-from legendary.models.manifest import ManifestComparison, Manifest
+from legendary.models.game import GameAsset
+from legendary.models.manifest import ManifestComparison, Manifest, CDL, ChunkInfo
 
 
 class DLManager(Process):
-    def __init__(self, download_dir, base_url, cache_dir=None, status_q=None,
+    def __init__(self, download_dir, base_url, use_signed_chunk_urls: bool, asset: GameAsset,
+                 cache_dir=None, status_q=None,
                  max_workers=0, update_interval=1.0, dl_timeout=10, resume_file=None,
                  max_shared_memory=1024 * 1024 * 1024, bind_ip=None):
         super().__init__(name='DLManager')
@@ -30,6 +34,13 @@ class DLManager(Process):
         self.base_url = base_url
         self.dl_dir = download_dir
         self.cache_dir = cache_dir or os.path.join(download_dir, '.cache')
+        self.use_signed_chunk_urls = use_signed_chunk_urls
+        self.asset = asset
+        # Called with (<ticket>, <list of chunk paths>), expected to return signed chunk URLs
+        self.sign_pipe: Optional[Connection] = None
+        # Called with (<catalogItemId>, <buildVersion>, <appName>, <namespace>, <label>, <platform>), expected to return
+        # ticket for signing chunk URLs (see `DownloadTicket`) in JSON format
+        self.ticket_pipe: Optional[Connection] = None
 
         # All the queues!
         self.logging_queue = None
@@ -37,6 +48,7 @@ class DLManager(Process):
         self.writer_queue = None
         self.dl_result_q = None
         self.writer_result_q = None
+        self.signed_chunks_q: Optional[MPQueue[tuple[ChunkInfo | TerminateWorkerTask, Optional[str]]]] = None
 
         # Worker stuff
         self.max_workers = max_workers or min(cpu_count() * 2, 16)
@@ -463,26 +475,80 @@ class DLManager(Process):
 
         return analysis_res
 
-    def download_job_manager(self, task_cond: Condition, shm_cond: Condition):
+    def chunk_signing_manager(self, sig_chunks_cond: Condition):
+        if self.use_signed_chunk_urls:
+            self._do_chunk_signing(sig_chunks_cond)
+            return
+
+        # If we're not using signed URLs, just pretend the raw chunks are the signed ones
+        for guid in self.chunks_to_dl:
+            self.signed_chunks_q.put((self.chunk_data_list.get_chunk_by_guid(guid), None))
+
+
+    def _do_chunk_signing(self, sig_chunks_cond: Condition):
+        ticket = self._gen_ticket()
         while self.chunks_to_dl and self.running:
-            while self.active_tasks < self.max_workers * 2 and self.chunks_to_dl:
+            if not self.signed_chunks_q.empty():
+                sleep(1)
+                continue
+
+            self.log.debug('Fetching more chunk URLs...')
+            num_of_chunks_to_fetch = min(len(self.chunks_to_dl), 50)
+            unprocessed_chunk_ids = list(self.chunks_to_dl.popleft() for _ in range(num_of_chunks_to_fetch))
+            unprocessed_chunks = list(self.chunk_data_list.get_chunk_by_guid(guid) for guid in unprocessed_chunk_ids)
+
+            if ticket.remaining_time < datetime.timedelta(minutes=5):
+                self.log.debug('Refreshing ticket')
+                ticket = self._gen_ticket()
+
+            self.sign_pipe.send((ticket.signedTicket, list(c.path for c in unprocessed_chunks)))
+
+            signed_urls: dict[str, str] = self.sign_pipe.recv()
+            for chunk in unprocessed_chunks:
+                signed_url = signed_urls[chunk.path]
+                self.signed_chunks_q.put((chunk, signed_url))
+                with sig_chunks_cond:
+                    sig_chunks_cond.notify()
+
+    def _gen_ticket(self) -> DownloadTicket:
+        # TODO: Verify this works on all games
+        label, platform = self.asset.label_name.split('-')
+        self.ticket_pipe.send((
+            self.asset.catalog_item_id, self.asset.build_version, self.asset.app_name, self.asset.namespace,
+            label, platform
+        ))
+        return DownloadTicket.from_json(self.ticket_pipe.recv())
+
+    def download_job_manager(self, task_cond: Condition, shm_cond: Condition, sig_chunks_cond: Condition):
+        terminate = False
+        while self.running and not terminate:
+            no_shm = False
+            no_signed_chunks = False
+            while self.active_tasks < self.max_workers * 2:
                 try:
                     sms = self.sms.popleft()
-                    no_shm = False
                 except IndexError:  # no free cache
                     no_shm = True
                     break
 
-                c_guid = self.chunks_to_dl.popleft()
-                chunk = self.chunk_data_list.get_chunk_by_guid(c_guid)
+                try:
+                    chunk, url = self.signed_chunks_q.get(False, 3.0)
+                except Empty:
+                    no_signed_chunks = True
+                    break
+
+                if isinstance(chunk, TerminateWorkerTask):
+                    terminate = True
+                    break
+
                 self.log.debug(f'Adding {chunk.guid_num} (active: {self.active_tasks})')
                 try:
-                    self.dl_worker_queue.put(DownloaderTask(url=self.base_url + '/' + chunk.path,
-                                                            chunk_guid=c_guid, shm=sms),
+                    self.dl_worker_queue.put(DownloaderTask(url=url or (self.base_url + '/' + chunk.path),
+                                                            chunk_guid=chunk.guid_num, shm=sms),
                                              timeout=1.0)
                 except Exception as e:
                     self.log.warning(f'Failed to add to download queue: {e!r}')
-                    self.chunks_to_dl.appendleft(c_guid)
+                    self.signed_chunks_q.put((chunk, url))
                     break
 
                 self.active_tasks += 1
@@ -498,6 +564,11 @@ class DLManager(Process):
                 with shm_cond:
                     self.log.debug('Waiting for more shared memory...')
                     shm_cond.wait(timeout=1.0)
+
+            if no_signed_chunks:
+                with sig_chunks_cond:
+                    self.log.debug('Waiting for more signed cunks...')
+                    sig_chunks_cond.wait(timeout=1.0)
 
         self.log.debug('Download Job Manager quitting...')
 
@@ -659,8 +730,14 @@ class DLManager(Process):
                     child.terminate()
 
             # clean up all the queues, otherwise this process won't terminate properly
-            for name, q in zip(('Download jobs', 'Writer jobs', 'Download results', 'Writer results'),
-                               (self.dl_worker_queue, self.writer_queue, self.dl_result_q, self.writer_result_q)):
+            queues: list[tuple[str, Optional[MPQueue]]] = [
+                ('Download jobs', self.dl_worker_queue),
+                ('Writer jobs', self.writer_queue),
+                ('Download results', self.dl_result_q),
+                ('Writer results', self.writer_result_q),
+                ('Signed chunks', self.signed_chunks_q)
+            ]
+            for name, q in queues:
                 self.log.debug(f'Cleaning up queue "{name}"')
                 try:
                     while True:
@@ -668,6 +745,12 @@ class DLManager(Process):
                 except Empty:
                     q.close()
                     q.join_thread()
+
+            # clean up connections
+            pipes = [self.sign_pipe, self.ticket_pipe]
+            for pipe in pipes:
+                if pipe is not None:
+                    pipe.close()
 
     def run_real(self):
         self.shared_memory = SharedMemory(create=True, size=self.max_shared_memory)
@@ -686,6 +769,7 @@ class DLManager(Process):
         self.writer_queue = MPQueue(-1)
         self.dl_result_q = MPQueue(-1)
         self.writer_result_q = MPQueue(-1)
+        self.signed_chunks_q = MPQueue(-1)
 
         self.log.info(f'Starting download workers...')
 
@@ -722,11 +806,13 @@ class DLManager(Process):
         # synchronization conditions
         shm_cond = Condition()
         task_cond = Condition()
-        self.conditions = [shm_cond, task_cond]
+        sig_chunks_cond = Condition()
+        self.conditions = [shm_cond, task_cond, sig_chunks_cond]
 
         # start threads
         s_time = time.time()
-        self.threads.append(Thread(target=self.download_job_manager, args=(task_cond, shm_cond)))
+        self.threads.append(Thread(target=self.chunk_signing_manager, args=(sig_chunks_cond,)))
+        self.threads.append(Thread(target=self.download_job_manager, args=(task_cond, shm_cond, sig_chunks_cond)))
         self.threads.append(Thread(target=self.dl_results_handler, args=(task_cond,)))
         self.threads.append(Thread(target=self.fw_results_handler, args=(shm_cond,)))
 
@@ -805,6 +891,7 @@ class DLManager(Process):
 
         self.log.info('Waiting for installation to finish...')
         self.writer_queue.put_nowait(TerminateWorkerTask())
+        self.signed_chunks_q.put_nowait((TerminateWorkerTask(), None))
 
         writer_p.join(timeout=10.0)
         if writer_p.exitcode is None:

--- a/legendary/models/downloading.py
+++ b/legendary/models/downloading.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 
+import datetime
 from enum import Flag, auto
 from dataclasses import dataclass
 from typing import Optional
@@ -140,6 +141,7 @@ class AnalysisResult:
     added: int = 0
     changed: int = 0
     unchanged: int = 0
+    use_signed_url: bool = False
     manifest_comparison: Optional[ManifestComparison] = None
 
 
@@ -158,3 +160,22 @@ class TerminateWorkerTask:
     """
     pass
 
+@dataclass
+class DownloadTicket:
+    """
+    Ticket to use for requesting signed chunk URLs
+    """
+    signedTicket: str
+    expiresAt: datetime.datetime
+
+    @classmethod
+    def from_json(cls, data: dict):
+        return cls(data['signedTicket'], datetime.datetime.fromisoformat(data['expiresAt']))
+
+    @property
+    def remaining_time(self) -> datetime.timedelta:
+        return self.expiresAt - datetime.datetime.now(self.expiresAt.tzinfo)
+
+    @property
+    def is_expired(self) -> bool:
+        return self.expiresAt < datetime.datetime.now(self.expiresAt.tzinfo)

--- a/legendary/models/game.py
+++ b/legendary/models/game.py
@@ -193,6 +193,7 @@ class InstalledGame:
     requires_ot: bool = False
     save_path: Optional[str] = None
     save_timestamp: Optional[float] = None
+    use_signed_url: bool = False
 
     @classmethod
     def from_json(cls, json):
@@ -220,6 +221,7 @@ class InstalledGame:
         tmp.install_size = json.get('install_size', 0)
         tmp.egl_guid = json.get('egl_guid', '')
         tmp.install_tags = json.get('install_tags', [])
+        tmp.use_signed_url = json.get('use_signed_url', False)
         return tmp
 
 

--- a/legendary/models/manifest.py
+++ b/legendary/models/manifest.py
@@ -341,13 +341,13 @@ class CDL:
         self.version = 0
         self.size = 0
         self.count = 0
-        self.elements = []
+        self.elements: list[ChunkInfo] = []
         self._manifest_version = 18
         self._guid_map = None
         self._guid_int_map = None
         self._path_map = None
 
-    def get_chunk_by_path(self, path):
+    def get_chunk_by_path(self, path) -> ChunkInfo:
         if not self._path_map:
             self._path_map = dict()
             for index, chunk in enumerate(self.elements):
@@ -358,7 +358,7 @@ class CDL:
             raise ValueError(f'Invalid path! "{path}"')
         return self.elements[index]
 
-    def get_chunk_by_guid(self, guid):
+    def get_chunk_by_guid(self, guid) -> ChunkInfo:
         """
         Get chunk by GUID string or number, creates index of chunks on first call
 
@@ -372,7 +372,7 @@ class CDL:
         else:
             return self.get_chunk_by_guid_str(guid)
 
-    def get_chunk_by_guid_str(self, guid):
+    def get_chunk_by_guid_str(self, guid) -> ChunkInfo:
         if not self._guid_map:
             self._guid_map = dict()
             for index, chunk in enumerate(self.elements):
@@ -383,7 +383,7 @@ class CDL:
             raise ValueError(f'Invalid GUID! {guid}')
         return self.elements[index]
 
-    def get_chunk_by_guid_num(self, guid_int):
+    def get_chunk_by_guid_num(self, guid_int) -> ChunkInfo:
         if not self._guid_int_map:
             self._guid_int_map = dict()
             for index, chunk in enumerate(self.elements):


### PR DESCRIPTION
Adds support for signed chunk download URLs, introduced by Epic a few days ago

To download chunks, Legendary now first requests a download ticket (with some relevant game metadata), and then runs chunk paths through another API to get signed URLs

This required quite a bit of inter-connectivity between the main & download manager processes; I've tried to keep this as clean as possible

I've confirmed both that games not using this system download fine with the old behavior, and games using the system download fine with the new.
Interestingly enough, games without this support still download fine if forced to use the system, and some even require it to download (reportedly this fixes Risk of Rain 2). To help in such cases, the `--always-use-signed-urls` parameter was added to the install command