### PR TITLE
Increase timeout for game assets retrieval to prevent timeouts with large libraries

### DIFF
--- a/legendary/api/egs.py
+++ b/legendary/api/egs.py
@@ -167,8 +167,9 @@ class EPCAPI:
         return r.json()
 
     def get_game_assets(self, platform='Windows', label='Live'):
+        forced_timeout = 60.0
         r = self.session.get(f'https://{self._launcher_host}/launcher/api/public/assets/{platform}',
-                             params=dict(label=label), timeout=self.request_timeout)
+                             params=dict(label=label), timeout=forced_timeout)  # placed 60 second timeout
         r.raise_for_status()
         return r.json()
 


### PR DESCRIPTION
### Problem
Users with large game libraries (600+ titles) or slower network connections experience `ReadTimeout` errors when retrieving their game list through `get_game_assets()`. The current 10-second timeout is insufficient for these cases.

### Solution
- Increased timeout from 10 to 60 seconds in `get_game_assets()` method
- This provides sufficient time for the API call to complete even with large libraries

### Testing
- Tested with user having ~600 games in library
- Previously failed with 10s timeout, now works reliably with 60s timeout
- No negative impact for users with smaller libraries

### Notes
The timeout increase only affects the specific API call that retrieves game assets, not other API operations.

**Related:** Heroic-Games-Launcher/HeroicGamesLauncher#4945