### PR TITLE
feat: implement proper timeout handling for large Epic libraries

### DIFF
--- a/legendary/api/egs.py
+++ b/legendary/api/egs.py
@@ -166,9 +166,11 @@ class EPCAPI:
         r.raise_for_status()
         return r.json()
 
-    def get_game_assets(self, platform='Windows', label='Live'):
+    def get_game_assets(self, platform='Windows', label='Live', timeout=None):
+        effective_timeout = timeout or self.request_timeout
+
         r = self.session.get(f'https://{self._launcher_host}/launcher/api/public/assets/{platform}',
-                             params=dict(label=label), timeout=self.request_timeout)
+                             params=dict(label=label), timeout=effective_timeout)
         r.raise_for_status()
         return r.json()
 

--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -200,9 +200,13 @@ class LegendaryCLI:
         else:
             logger.info('Getting game list... (this may take a while)')
 
+        # Übergib asset_timeout an die Core-Funktion
+        asset_timeout = getattr(args, 'asset_timeout', None)
+
         games, dlc_list = self.core.get_game_and_dlc_list(
             platform=args.platform, skip_ue=not args.include_ue,
-            force_refresh=args.force_refresh
+            force_refresh=args.force_refresh,
+            asset_timeout=getattr(args, 'asset_timeout', None)
         )
         # Get information for games that cannot be installed through legendary (yet), such
         # as games that have to be activated on and launched through Origin.
@@ -2825,6 +2829,11 @@ def main():
                                           description='Note: additional arguments are passed to the game')
     list_parser = subparsers.add_parser('list', aliases=('list-games',), hide_aliases=True,
                                         help='List available (installable) games')
+
+    list_parser.add_argument('--asset-timeout', dest='asset_timeout', action='store',
+                             type=float, metavar='<seconds>',
+                             help='Timeout for asset requests in seconds (default: 10)')
+
     list_files_parser = subparsers.add_parser('list-files', help='List files in manifest')
     list_installed_parser = subparsers.add_parser('list-installed', help='List installed games')
     list_saves_parser = subparsers.add_parser('list-saves', help='List available cloud saves')

--- a/legendary/core.py
+++ b/legendary/core.py
@@ -346,7 +346,7 @@ class LegendaryCore:
         if _aliases_enabled and (force or not self.lgd.aliases):
             self.lgd.generate_aliases()
 
-    def get_assets(self, update_assets=False, platform='Windows') -> List[GameAsset]:
+    def get_assets(self, update_assets=False, platform='Windows', asset_timeout=None) -> List[GameAsset]:
         # do not save and always fetch list when platform is overridden
         if not self.lgd.assets or update_assets or platform not in self.lgd.assets:
             # if not logged in, return empty list
@@ -358,7 +358,7 @@ class LegendaryCore:
             assets.update({
                 platform: [
                     GameAsset.from_egs_json(a) for a in
-                    self.egs.get_game_assets(platform=platform)
+                    self.egs.get_game_assets(platform=platform, timeout=asset_timeout)
                 ]
             })
 
@@ -368,9 +368,9 @@ class LegendaryCore:
 
         return self.lgd.assets[platform]
 
-    def get_asset(self, app_name, platform='Windows', update=False) -> GameAsset:
+    def get_asset(self, app_name, platform='Windows', update=False, asset_timeout=None) -> GameAsset:
         if update or platform not in self.lgd.assets:
-            self.get_assets(update_assets=True, platform=platform)
+            self.get_assets(update_assets=True, platform=platform, asset_timeout=asset_timeout)
 
         try:
             return next(i for i in self.lgd.assets[platform] if i.app_name == app_name)
@@ -397,11 +397,11 @@ class LegendaryCore:
             self.get_game_list(True, platform=platform)
         return self.lgd.get_game_meta(app_name)
 
-    def get_game_list(self, update_assets=True, platform='Windows') -> List[Game]:
-        return self.get_game_and_dlc_list(update_assets=update_assets, platform=platform)[0]
+    def get_game_list(self, update_assets=True, platform='Windows', asset_timeout=None) -> List[Game]:
+        return self.get_game_and_dlc_list(update_assets=update_assets, platform=platform, asset_timeout=asset_timeout)[0]
 
     def get_game_and_dlc_list(self, update_assets=True, platform='Windows',
-                              force_refresh=False, skip_ue=True) -> (List[Game], Dict[str, List[Game]]):
+                              force_refresh=False, skip_ue=True, asset_timeout=None) -> (List[Game], Dict[str, List[Game]]):
         _ret = []
         _dlc = defaultdict(list)
         meta_updated = False
@@ -412,7 +412,7 @@ class LegendaryCore:
         platforms |= self.get_installed_platforms()
 
         for _platform in platforms:
-            self.get_assets(update_assets=update_assets, platform=_platform)
+            self.get_assets(update_assets=update_assets, platform=_platform, asset_timeout=asset_timeout)
 
         if not self.lgd.assets:
             return _ret, _dlc


### PR DESCRIPTION
## Problem
Users with large game libraries (600+ titles) or slower network connections experience ReadTimeout errors when retrieving their game list through get_game_assets(). The current 10-second timeout is insufficient for these cases.

## Solution
Instead of a fixed timeout increase (as proposed in #25), this PR adds a **configurable `--asset-timeout` parameter** that:
- Maintains backward compatibility (default: 10 seconds)
- Allows users with large libraries to increase timeout as needed (e.g., `--asset-timeout 30`)
- Provides flexibility for different network conditions

## Improvements over previous approach
- ✅ No hardcoded values affecting all users
- ✅ Users can adjust based on their specific needs  
- ✅ Cleaner, more maintainable architecture
- ✅ Better separation of concerns

## Testing
- Tested with user having ~600 games in library
- Default behavior unchanged (10s timeout)
- Configurable timeout works reliably (tested with 30s, 60s)
- No negative impact for users with smaller libraries

## Related
Replaces approach from #25
Related: Heroic-Games-Launcher/HeroicGamesLauncher#4945