### PR TITLE
Don't use the raw runner name as the artifact name

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -55,5 +55,5 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.os }}-package
+        name: ${{ runner.os }}-${{ runner.arch }}-package
         path: legendary/dist/*


### PR DESCRIPTION
This makes the artifact names a little friendlier. They are just titled `<os>-<arch>-package` now, so users no longer assume the artifact is for a specific OS version (e.g. Ubuntu instead of Linux)