### PR TITLE
Revert "Also consider "ThirdPartyManagedProvider" attribute when check..."

### DIFF
--- a/legendary/models/game.py
+++ b/legendary/models/game.py
@@ -93,14 +93,7 @@ class Game:
     def third_party_store(self) -> Optional[str]:
         if not self.metadata:
             return None
-
-        custom_attributes: dict[str, dict] = self.metadata.get('customAttributes', {})
-        for key in ['ThirdPartyManagedApp', 'ThirdPartyManagedProvider']:
-            if key not in custom_attributes:
-                continue
-            return custom_attributes.get(key).get('value')
-
-        return None
+        return self.metadata.get('customAttributes', {}).get('ThirdPartyManagedApp', {}).get('value', None)
 
     @property
     def partner_link_type(self):


### PR DESCRIPTION
Revert this commit https://github.com/Heroic-Games-Launcher/legendary/commit/18af8900ed185d0459ab84fd858435bbffc24083 so Ubisoft games can be installed.

Some Ubisoft games are not installable anyway like Assassin's Creed Shadows, but that will need a different solution to address.