### PR TITLE
manager.py: Return shared memory segments to pool on error paths

### DIFF
--- a/legendary-dev
+++ b/legendary-dev
@@ -1,0 +1,3 @@
+#!/bin/bash
+exec /home/paraguayo33/legendary/.venv/bin/python \
+  /home/paraguayo33/legendary/legendary/cli.py "$@"

--- a/legendary/__init__.py
+++ b/legendary/__init__.py
@@ -1,4 +1,4 @@
 """Legendary!"""
 
 __version__ = '0.20.43'
-__codename__ = 'Riding Shotgun (Heroic)'
+__codename__ = 'Riding Shotgun (Heroic-dev)'

--- a/legendary/downloader/mp/manager.py
+++ b/legendary/downloader/mp/manager.py
@@ -519,10 +519,11 @@ class DLManager(Process):
 
             signed_urls: dict[str, str] = self.sign_pipe.recv()
             for chunk in unprocessed_chunks:
-                signed_url = signed_urls[chunk.path]
-                self.signed_chunks_q.put((chunk, signed_url))
-                with sig_chunks_cond:
-                    sig_chunks_cond.notify()
+                self.signed_chunks_q.put((chunk, signed_urls[chunk.path]))
+            # One notification per batch is enough — download_job_manager wakes
+            # once and then drains whatever is in the queue without re-waiting.
+            with sig_chunks_cond:
+                sig_chunks_cond.notify()
 
     def _gen_ticket(self) -> DownloadTicket:
         # TODO: Verify this works on all games
@@ -562,7 +563,7 @@ class DLManager(Process):
                     break
 
                 try:
-                    chunk, url = self.signed_chunks_q.get(False, 3.0)
+                    chunk, url = self.signed_chunks_q.get(block=False)
                 except Empty:
                     no_signed_chunks = True
                     break
@@ -598,7 +599,7 @@ class DLManager(Process):
 
             if no_signed_chunks:
                 with sig_chunks_cond:
-                    self.log.debug('Waiting for more signed cunks...')
+                    self.log.debug('Waiting for more signed chunks...')
                     sig_chunks_cond.wait(timeout=1.0)
 
         self.log.debug('Download Job Manager quitting...')

--- a/legendary/downloader/mp/manager.py
+++ b/legendary/downloader/mp/manager.py
@@ -487,17 +487,26 @@ class DLManager(Process):
         # If we're not using signed URLs, just pretend the raw chunks are the signed ones
         for guid in self.chunks_to_dl:
             self.signed_chunks_q.put((self.chunk_data_list.get_chunk_by_guid(guid), None))
+        # Wake up download_job_manager — it may be waiting on sig_chunks_cond
+        with sig_chunks_cond:
+            sig_chunks_cond.notify_all()
 
 
     def _do_chunk_signing(self, sig_chunks_cond: Condition):
         ticket = self._gen_ticket()
+        # Keep signed_chunks_q filled ahead of workers: fetch when it drops below this threshold
+        prefetch_threshold = self.max_workers * 4
         while self.chunks_to_dl and self.running:
-            if not self.signed_chunks_q.empty():
+            try:
+                pending = self.signed_chunks_q.qsize()
+            except NotImplementedError:
+                pending = 0 if self.signed_chunks_q.empty() else prefetch_threshold
+            if pending >= prefetch_threshold:
                 sleep(0.05)
                 continue
 
             self.log.debug('Fetching more chunk URLs...')
-            num_of_chunks_to_fetch = min(len(self.chunks_to_dl), 50)
+            num_of_chunks_to_fetch = min(len(self.chunks_to_dl), 100)
             unprocessed_chunk_ids = list(self.chunks_to_dl.popleft() for _ in range(num_of_chunks_to_fetch))
             unprocessed_chunks = list(self.chunk_data_list.get_chunk_by_guid(guid) for guid in unprocessed_chunk_ids)
 
@@ -525,10 +534,26 @@ class DLManager(Process):
 
     def download_job_manager(self, task_cond: Condition, shm_cond: Condition, sig_chunks_cond: Condition):
         terminate = False
+        _last_resource_check = 0.0
+        _load_factor = 1.0
         while self.running and not terminate:
             no_shm = False
             no_signed_chunks = False
-            while self.active_tasks < self.max_workers * 2:
+
+            # Re-evaluate CPU load every 5 s (cheap: one getloadavg call).
+            now = time.monotonic()
+            if now - _last_resource_check > 5.0:
+                _load_factor = self._cpu_load_factor()
+                _last_resource_check = now
+
+            # Dynamic target: scale with available SHM (disk pressure) and CPU load.
+            # avail_shm high → disk is fast → allow more in-flight downloads.
+            # avail_shm low  → disk is the bottleneck → reduce pressure.
+            # _load_factor < 1.0 → system under CPU load → back off further.
+            avail_shm = len(self.sms)
+            shm_target = max(self.max_workers, min(self.max_workers * 4, avail_shm // 2))
+            target_inflight = max(1, int(shm_target * _load_factor))
+            while self.active_tasks < target_inflight:
                 try:
                     sms = self.sms.popleft()
                 except IndexError:  # no free cache
@@ -656,12 +681,31 @@ class DLManager(Process):
         self.log.debug('Download result handler quitting...')
 
     def fw_results_handler(self, shm_cond: Condition):
+        # Buffer resume-file lines and flush in batches to avoid opening the
+        # file on every completed file (10 000+ times for large games).
+        _resume_buf: list = []
+        _resume_file_handle = None
+        if self.resume_file:
+            try:
+                _resume_file_handle = open(self.resume_file, 'a', encoding='utf-8')
+            except OSError as e:
+                self.log.warning(f'Could not open resume file for writing: {e!r}')
+
+        def _flush_resume():
+            if _resume_file_handle and _resume_buf:
+                _resume_file_handle.writelines(_resume_buf)
+                _resume_file_handle.flush()
+                _resume_buf.clear()
+
         while self.running:
             try:
                 res = self.writer_result_q.get(timeout=1.0)
 
                 if isinstance(res, TerminateWorkerTask):
                     self.log.debug('Got termination command in FW result handler')
+                    _flush_resume()
+                    if _resume_file_handle:
+                        _resume_file_handle.close()
                     break
 
                 self.num_tasks_processed_since_last += 1
@@ -671,9 +715,10 @@ class DLManager(Process):
                         res.filename = res.filename[:-4]
 
                     file_hash = self.hash_map[res.filename]
-                    # write last completed file to super simple resume file
-                    with open(self.resume_file, 'a', encoding='utf-8') as rf:
-                        rf.write(f'{file_hash}:{res.filename}\n')
+                    _resume_buf.append(f'{file_hash}:{res.filename}\n')
+                    # Flush every 20 files or when buffer grows large
+                    if len(_resume_buf) >= 20:
+                        _flush_resume()
 
                 if not res.success:
                     # todo make this kill the installation process or at least skip the file and mark it as failed
@@ -760,7 +805,50 @@ class DLManager(Process):
             self.shared_memory.unlink()
             self.shared_memory = None
 
+    @staticmethod
+    def _available_ram_bytes() -> int:
+        """Return MemAvailable from /proc/meminfo in bytes. Returns 0 on error or non-Linux."""
+        try:
+            with open('/proc/meminfo') as f:
+                for line in f:
+                    if line.startswith('MemAvailable:'):
+                        return int(line.split()[1]) * 1024
+        except Exception:
+            pass
+        return 0
+
+    @staticmethod
+    def _cpu_load_factor() -> float:
+        """
+        Return 0.25–1.0 representing how much of the download budget to use.
+        1.0 = system idle, drops as load increases relative to CPU count.
+        """
+        try:
+            load_1min = os.getloadavg()[0]
+            ncpu = os.cpu_count() or 1
+            # At load == ncpu (all cores busy): factor ~= 0.5
+            # At load >= 2×ncpu: factor = 0.25 (floor)
+            return max(0.25, 1.0 - (load_1min / ncpu) * 0.5)
+        except Exception:
+            return 1.0
+
     def run_real(self):
+        # Cap shared memory against available system RAM before allocating.
+        # Never use more than 40 % of what the OS reports as free, but always
+        # keep at least enough for 2 chunks per worker so the pipeline can run.
+        avail_ram = self._available_ram_bytes()
+        if avail_ram > 0:
+            ram_cap = int(avail_ram * 0.4)
+            min_shm = self.analysis.biggest_chunk * self.max_workers * 2
+            if self.max_shared_memory > ram_cap:
+                adjusted = max(ram_cap, min_shm)
+                self.log.info(
+                    f'Reducing shared memory {self.max_shared_memory // 1024 // 1024} MiB → '
+                    f'{adjusted // 1024 // 1024} MiB '
+                    f'(available RAM: {avail_ram // 1024 // 1024} MiB)'
+                )
+                self.max_shared_memory = adjusted
+
         self.shared_memory = SharedMemory(create=True, size=self.max_shared_memory)
         self.log.debug(f'Created shared memory of size: {self.shared_memory.size / 1024 / 1024:.02f} MiB')
 

--- a/legendary/downloader/mp/manager.py
+++ b/legendary/downloader/mp/manager.py
@@ -536,25 +536,16 @@ class DLManager(Process):
 
     def download_job_manager(self, task_cond: Condition, shm_cond: Condition, sig_chunks_cond: Condition):
         terminate = False
-        _last_resource_check = 0.0
-        _load_factor = 1.0
         while self.running and not terminate:
             no_shm = False
             no_signed_chunks = False
 
-            # Re-evaluate CPU load every 5 s (cheap: one getloadavg call).
-            now = time.monotonic()
-            if now - _last_resource_check > 5.0:
-                _load_factor = self._cpu_load_factor()
-                _last_resource_check = now
-
-            # Dynamic target: scale with available SHM (disk pressure) and CPU load.
-            # avail_shm high → disk is fast → allow more in-flight downloads.
-            # avail_shm low  → disk is the bottleneck → reduce pressure.
-            # _load_factor < 1.0 → system under CPU load → back off further.
+            # Throttle based on available SHM only: high avail_shm → disk keeping
+            # up → allow more downloads; low avail_shm → disk is the bottleneck.
+            # CPU-load throttling was removed: getloadavg() counts our own worker
+            # processes as load, causing the pipeline to throttle itself.
             avail_shm = len(self.sms)
-            shm_target = max(self.max_workers, min(self.max_workers * 4, avail_shm // 2))
-            target_inflight = max(1, int(shm_target * _load_factor))
+            target_inflight = max(self.max_workers, min(self.max_workers * 4, avail_shm // 2))
             while self.active_tasks < target_inflight:
                 try:
                     sms = self.sms.popleft()
@@ -575,8 +566,7 @@ class DLManager(Process):
                 self.log.debug(f'Adding {chunk.guid_num} (active: {self.active_tasks})')
                 try:
                     self.dl_worker_queue.put(DownloaderTask(url=url or (self.base_url + '/' + chunk.path),
-                                                            chunk_guid=chunk.guid_num, shm=sms,
-                                                            compressed_size=chunk.file_size),
+                                                            chunk_guid=chunk.guid_num, shm=sms),
                                                          timeout=1.0)
                 except Exception as e:
                     self.log.warning(f'Failed to add to download queue: {e!r}')
@@ -604,28 +594,18 @@ class DLManager(Process):
 
         self.log.debug('Download Job Manager quitting...')
 
-    def dl_results_handler(self, task_cond: Condition, num_file_workers: int = 1):
+    def dl_results_handler(self, task_cond: Condition):
         in_buffer = dict()
 
         task = self.tasks.popleft()
         current_file = ''
 
-        # When num_file_workers == 2, alternate between the two writer queues on each
-        # OPEN_FILE so two files are written in parallel.  All tasks for the same file
-        # (OPEN → chunks → CLOSE → RENAME/CHMOD) always stay on the same queue.
-        _writer_qs = [self.writer_queue, self.writer_queue_2]
-        _q_idx = 0
-        _wq = self.writer_queue  # single-worker default
-
         while task and self.running:
             if isinstance(task, FileTask):  # this wasn't necessarily a good idea...
                 try:
                     if task.flags & TaskFlags.OPEN_FILE:
-                        if num_file_workers > 1:
-                            _wq = _writer_qs[_q_idx % 2]
-                            _q_idx += 1
                         current_file = task.filename
-                    _wq.put(WriterTask(**task.__dict__), timeout=1.0)
+                    self.writer_queue.put(WriterTask(**task.__dict__), timeout=1.0)
                 except Exception as e:
                     self.tasks.appendleft(task)
                     self.log.warning(f'Adding to queue failed: {e!r}')
@@ -644,7 +624,7 @@ class DLManager(Process):
 
                 try:
                     self.log.debug(f'Adding {task.chunk_guid} to writer queue')
-                    _wq.put(WriterTask(
+                    self.writer_queue.put(WriterTask(
                         filename=current_file, shared_memory=res_shm,
                         chunk_offset=task.chunk_offset, chunk_size=task.chunk_size,
                         chunk_guid=task.chunk_guid, old_file=task.chunk_file,
@@ -693,7 +673,7 @@ class DLManager(Process):
 
         self.log.debug('Download result handler quitting...')
 
-    def fw_results_handler(self, shm_cond: Condition, num_file_workers: int = 1):
+    def fw_results_handler(self, shm_cond: Condition):
         # Buffer resume-file lines and flush in batches to avoid opening the
         # file on every completed file (10 000+ times for large games).
         _resume_buf: list = []
@@ -710,20 +690,16 @@ class DLManager(Process):
                 _resume_file_handle.flush()
                 _resume_buf.clear()
 
-        _terminated = 0
         while self.running:
             try:
                 res = self.writer_result_q.get(timeout=1.0)
 
                 if isinstance(res, TerminateWorkerTask):
-                    _terminated += 1
-                    self.log.debug(f'FW result handler: worker terminated ({_terminated}/{num_file_workers})')
-                    if _terminated >= num_file_workers:
-                        _flush_resume()
-                        if _resume_file_handle:
-                            _resume_file_handle.close()
-                        break
-                    continue
+                    self.log.debug('FW result handler: worker terminated')
+                    _flush_resume()
+                    if _resume_file_handle:
+                        _resume_file_handle.close()
+                    break
 
                 self.num_tasks_processed_since_last += 1
 
@@ -844,104 +820,30 @@ class DLManager(Process):
             pass
         return 0
 
-    @staticmethod
-    def _cpu_load_factor() -> float:
-        """
-        Return 0.25–1.0 representing how much of the download budget to use.
-        1.0 = system idle, drops as load increases relative to CPU count.
-        """
-        try:
-            load_1min = os.getloadavg()[0]
-            ncpu = os.cpu_count() or 1
-            # At load == ncpu (all cores busy): factor ~= 0.5
-            # At load >= 2×ncpu: factor = 0.25 (floor)
-            return max(0.25, 1.0 - (load_1min / ncpu) * 0.5)
-        except Exception:
-            return 1.0
-
-    @staticmethod
-    def _parallel_writers_for_path(path: str) -> int:
-        """
-        Return the optimal number of parallel FileWorkers for *path*.
-        Returns 2 on SSD/NVMe with a filesystem that handles concurrent writes well,
-        1 on HDD (parallel writes cause seek thrashing) or unknown storage.
-        """
-        _parallel_fs = frozenset({'ext4', 'ext3', 'ext2', 'xfs', 'f2fs', 'btrfs', 'tmpfs'})
-
-        try:
-            from legendary.downloader.mp.workers import _fs_type_for_path
-            fs = _fs_type_for_path(path)
-        except Exception:
-            fs = ''
-
-        if fs not in _parallel_fs:
-            return 1
-
-        # Resolve which block device hosts this path
-        try:
-            real = os.path.realpath(path)
-            best_mp, device = '', ''
-            with open('/proc/mounts') as f:
-                for line in f:
-                    parts = line.split()
-                    if len(parts) >= 2 and real.startswith(parts[1]) and len(parts[1]) > len(best_mp):
-                        best_mp, device = parts[1], parts[0]
-
-            if not device.startswith('/dev/'):
-                return 1
-
-            dev_name = os.path.basename(os.path.realpath(device))
-
-            # Walk /sys/block to find the parent device (handles sda1→sda, nvme0n1p1→nvme0n1, etc.)
-            base = None
-            for bd in os.listdir('/sys/block/'):
-                if dev_name.startswith(bd) and (base is None or len(bd) > len(base)):
-                    base = bd
-
-            if not base:
-                return 1
-
-            with open(f'/sys/block/{base}/queue/rotational') as f:
-                is_ssd = f.read().strip() == '0'
-
-            return 2 if is_ssd else 1
-        except Exception:
-            return 1
-
     def run_real(self):
         avail_ram = self._available_ram_bytes()
 
-        # Minimum SHM: enough for every worker to have 2 in-flight chunks, plus
-        # any reuse requirement computed by the manifest analysis.
+        # SHM is demand-paged: only active chunks use physical RAM (~64 MB at
+        # max_workers*4 in-flight with 1 MiB chunks).  The virtual allocation
+        # must be large enough to buffer download-write rate mismatches — too
+        # small causes SHM pressure and oscillating download speeds.
+        # Use the caller-supplied value (default 1 GiB) and only reduce it on
+        # RAM-constrained systems (< 8 GiB available).
         min_shm = max(self.analysis.min_memory,
                       self.analysis.biggest_chunk * self.max_workers * 2)
+        target = max(self.max_shared_memory, min_shm)
 
-        # Pipeline-optimal SHM: target_inflight is capped at max_workers*4.
-        # To sustain that rate, avail_shm/2 must stay >= max_workers*4, which
-        # requires total_segments >= max_workers*12.  Hard-cap at 512 MiB —
-        # no game pipeline benefits from more (SHM is demand-paged so larger
-        # allocations don't cost physical RAM until written).
-        pipeline_shm = max(min_shm, min(self.analysis.biggest_chunk * self.max_workers * 12,
-                                        512 * 1024 * 1024))
-
-        # Respect caller-supplied ceiling (--max-shared-memory) but don't exceed
-        # what the pipeline can use.
-        target = min(pipeline_shm, self.max_shared_memory)
-        target = max(target, min_shm)
-
-        # Safety cap for memory-constrained systems (< 8 GiB available).
-        # On ample-RAM systems the pipeline_shm target is already small enough.
         if avail_ram > 0 and avail_ram < 8 * 1024 ** 3:
             fraction = 0.20 if avail_ram < 4 * 1024 ** 3 else 0.30
             ram_cap = max(min_shm, int(avail_ram * fraction))
-            target = min(target, ram_cap)
+            if target > ram_cap:
+                self.log.info(
+                    f'Shared memory reduced: {target // 1024 // 1024} MiB → '
+                    f'{ram_cap // 1024 // 1024} MiB '
+                    f'(RAM available: {avail_ram // 1024 // 1024} MiB)'
+                )
+                target = ram_cap
 
-        if target != self.max_shared_memory:
-            self.log.info(
-                f'Shared memory adjusted: {self.max_shared_memory // 1024 // 1024} MiB → '
-                f'{target // 1024 // 1024} MiB'
-                + (f' (RAM available: {avail_ram // 1024 // 1024} MiB)' if avail_ram > 0 else '')
-            )
         self.max_shared_memory = target
 
         self.shared_memory = SharedMemory(create=True, size=self.max_shared_memory)
@@ -955,15 +857,10 @@ class DLManager(Process):
 
         self.log.debug(f'Created {len(self.sms)} shared memory segments.')
 
-        # Detect storage type early so writer_queue_2 is only created when needed.
-        num_fw = self._parallel_writers_for_path(self.dl_dir)
-        storage_label = 'SSD/NVMe' if num_fw > 1 else 'HDD or unknown'
-        self.log.info(f'Starting {num_fw} file writing worker(s) (storage detected: {storage_label})')
-
         # Create queues
         self.dl_worker_queue = MPQueue(-1)
         self.writer_queue = MPQueue(-1)
-        self.writer_queue_2 = MPQueue(-1) if num_fw > 1 else None
+        self.writer_queue_2 = None
         self.dl_result_q = MPQueue(-1)
         self.writer_result_q = MPQueue(-1)
         self.signed_chunks_q = MPQueue(-1)
@@ -986,13 +883,7 @@ class DLManager(Process):
         self.children.append(writer_p)
         writer_p.start()
 
-        if num_fw > 1:
-            writer_p2 = FileWorker(self.writer_queue_2, self.writer_result_q, self.dl_dir,
-                                   self.shared_memory.name, self.cache_dir, self.logging_queue)
-            self.children.append(writer_p2)
-            writer_p2.start()
-        else:
-            writer_p2 = None
+        writer_p2 = None
 
         num_chunk_tasks = sum(isinstance(t, ChunkTask) for t in self.tasks)
         num_dl_tasks = len(self.chunks_to_dl)
@@ -1017,8 +908,8 @@ class DLManager(Process):
         s_time = time.time()
         self.threads.append(Thread(target=self.chunk_signing_manager, args=(sig_chunks_cond,)))
         self.threads.append(Thread(target=self.download_job_manager, args=(task_cond, shm_cond, sig_chunks_cond)))
-        self.threads.append(Thread(target=self.dl_results_handler, args=(task_cond, num_fw)))
-        self.threads.append(Thread(target=self.fw_results_handler, args=(shm_cond, num_fw)))
+        self.threads.append(Thread(target=self.dl_results_handler, args=(task_cond,)))
+        self.threads.append(Thread(target=self.fw_results_handler, args=(shm_cond,)))
 
         for t in self.threads:
             t.start()
@@ -1095,8 +986,6 @@ class DLManager(Process):
 
         self.log.info('Waiting for installation to finish...')
         self.writer_queue.put_nowait(TerminateWorkerTask())
-        if num_fw > 1:
-            self.writer_queue_2.put_nowait(TerminateWorkerTask())
         self.signed_chunks_q.put_nowait((TerminateWorkerTask(), None))
 
         writer_p.join(timeout=10.0)

--- a/legendary/downloader/mp/manager.py
+++ b/legendary/downloader/mp/manager.py
@@ -47,6 +47,7 @@ class DLManager(Process):
         self.logging_queue = None
         self.dl_worker_queue = None
         self.writer_queue = None
+        self.writer_queue_2 = None  # second parallel file writer
         self.dl_result_q = None
         self.writer_result_q = None
         self.signed_chunks_q: Optional[MPQueue[tuple[ChunkInfo | TerminateWorkerTask, Optional[str]]]] = None
@@ -601,18 +602,28 @@ class DLManager(Process):
 
         self.log.debug('Download Job Manager quitting...')
 
-    def dl_results_handler(self, task_cond: Condition):
+    def dl_results_handler(self, task_cond: Condition, num_file_workers: int = 1):
         in_buffer = dict()
 
         task = self.tasks.popleft()
         current_file = ''
 
+        # When num_file_workers == 2, alternate between the two writer queues on each
+        # OPEN_FILE so two files are written in parallel.  All tasks for the same file
+        # (OPEN → chunks → CLOSE → RENAME/CHMOD) always stay on the same queue.
+        _writer_qs = [self.writer_queue, self.writer_queue_2]
+        _q_idx = 0
+        _wq = self.writer_queue  # single-worker default
+
         while task and self.running:
             if isinstance(task, FileTask):  # this wasn't necessarily a good idea...
                 try:
-                    self.writer_queue.put(WriterTask(**task.__dict__), timeout=1.0)
                     if task.flags & TaskFlags.OPEN_FILE:
+                        if num_file_workers > 1:
+                            _wq = _writer_qs[_q_idx % 2]
+                            _q_idx += 1
                         current_file = task.filename
+                    _wq.put(WriterTask(**task.__dict__), timeout=1.0)
                 except Exception as e:
                     self.tasks.appendleft(task)
                     self.log.warning(f'Adding to queue failed: {e!r}')
@@ -631,7 +642,7 @@ class DLManager(Process):
 
                 try:
                     self.log.debug(f'Adding {task.chunk_guid} to writer queue')
-                    self.writer_queue.put(WriterTask(
+                    _wq.put(WriterTask(
                         filename=current_file, shared_memory=res_shm,
                         chunk_offset=task.chunk_offset, chunk_size=task.chunk_size,
                         chunk_guid=task.chunk_guid, old_file=task.chunk_file,
@@ -680,7 +691,7 @@ class DLManager(Process):
 
         self.log.debug('Download result handler quitting...')
 
-    def fw_results_handler(self, shm_cond: Condition):
+    def fw_results_handler(self, shm_cond: Condition, num_file_workers: int = 1):
         # Buffer resume-file lines and flush in batches to avoid opening the
         # file on every completed file (10 000+ times for large games).
         _resume_buf: list = []
@@ -697,16 +708,20 @@ class DLManager(Process):
                 _resume_file_handle.flush()
                 _resume_buf.clear()
 
+        _terminated = 0
         while self.running:
             try:
                 res = self.writer_result_q.get(timeout=1.0)
 
                 if isinstance(res, TerminateWorkerTask):
-                    self.log.debug('Got termination command in FW result handler')
-                    _flush_resume()
-                    if _resume_file_handle:
-                        _resume_file_handle.close()
-                    break
+                    _terminated += 1
+                    self.log.debug(f'FW result handler: worker terminated ({_terminated}/{num_file_workers})')
+                    if _terminated >= num_file_workers:
+                        _flush_resume()
+                        if _resume_file_handle:
+                            _resume_file_handle.close()
+                        break
+                    continue
 
                 self.num_tasks_processed_since_last += 1
 
@@ -739,6 +754,13 @@ class DLManager(Process):
                 continue
             except Exception as e:
                 self.log.warning(f'Exception when trying to read writer result queue: {e!r}')
+        # Flush and close resume file on any exit path (normal or self.running=False)
+        _flush_resume()
+        if _resume_file_handle:
+            try:
+                _resume_file_handle.close()
+            except OSError:
+                pass
         self.log.debug('Writer result handler quitting...')
 
     def run(self):
@@ -782,11 +804,14 @@ class DLManager(Process):
             queues: list[tuple[str, Optional[MPQueue]]] = [
                 ('Download jobs', self.dl_worker_queue),
                 ('Writer jobs', self.writer_queue),
+                ('Writer jobs 2', self.writer_queue_2),
                 ('Download results', self.dl_result_q),
                 ('Writer results', self.writer_result_q),
                 ('Signed chunks', self.signed_chunks_q)
             ]
             for name, q in queues:
+                if q is None:
+                    continue
                 self.log.debug(f'Cleaning up queue "{name}"')
                 try:
                     while True:
@@ -832,6 +857,55 @@ class DLManager(Process):
         except Exception:
             return 1.0
 
+    @staticmethod
+    def _parallel_writers_for_path(path: str) -> int:
+        """
+        Return the optimal number of parallel FileWorkers for *path*.
+        Returns 2 on SSD/NVMe with a filesystem that handles concurrent writes well,
+        1 on HDD (parallel writes cause seek thrashing) or unknown storage.
+        """
+        _parallel_fs = frozenset({'ext4', 'ext3', 'ext2', 'xfs', 'f2fs', 'btrfs', 'tmpfs'})
+
+        try:
+            from legendary.downloader.mp.workers import _fs_type_for_path
+            fs = _fs_type_for_path(path)
+        except Exception:
+            fs = ''
+
+        if fs not in _parallel_fs:
+            return 1
+
+        # Resolve which block device hosts this path
+        try:
+            real = os.path.realpath(path)
+            best_mp, device = '', ''
+            with open('/proc/mounts') as f:
+                for line in f:
+                    parts = line.split()
+                    if len(parts) >= 2 and real.startswith(parts[1]) and len(parts[1]) > len(best_mp):
+                        best_mp, device = parts[1], parts[0]
+
+            if not device.startswith('/dev/'):
+                return 1
+
+            dev_name = os.path.basename(os.path.realpath(device))
+
+            # Walk /sys/block to find the parent device (handles sda1→sda, nvme0n1p1→nvme0n1, etc.)
+            base = None
+            for bd in os.listdir('/sys/block/'):
+                if dev_name.startswith(bd) and (base is None or len(bd) > len(base)):
+                    base = bd
+
+            if not base:
+                return 1
+
+            with open(f'/sys/block/{base}/queue/rotational') as f:
+                is_ssd = f.read().strip() == '0'
+
+            return 2 if is_ssd else 1
+        except Exception:
+            return 1
+
     def run_real(self):
         # Cap shared memory against available system RAM before allocating.
         # Never use more than 40 % of what the OS reports as free, but always
@@ -863,6 +937,7 @@ class DLManager(Process):
         # Create queues
         self.dl_worker_queue = MPQueue(-1)
         self.writer_queue = MPQueue(-1)
+        self.writer_queue_2 = MPQueue(-1)
         self.dl_result_q = MPQueue(-1)
         self.writer_result_q = MPQueue(-1)
         self.signed_chunks_q = MPQueue(-1)
@@ -880,11 +955,22 @@ class DLManager(Process):
             self.children.append(w)
             w.start()
 
-        self.log.info('Starting file writing worker...')
+        num_fw = self._parallel_writers_for_path(self.dl_dir)
+        storage_label = 'SSD/NVMe' if num_fw > 1 else 'HDD or unknown'
+        self.log.info(f'Starting {num_fw} file writing worker(s) (storage detected: {storage_label})')
+
         writer_p = FileWorker(self.writer_queue, self.writer_result_q, self.dl_dir,
                               self.shared_memory.name, self.cache_dir, self.logging_queue)
         self.children.append(writer_p)
         writer_p.start()
+
+        if num_fw > 1:
+            writer_p2 = FileWorker(self.writer_queue_2, self.writer_result_q, self.dl_dir,
+                                   self.shared_memory.name, self.cache_dir, self.logging_queue)
+            self.children.append(writer_p2)
+            writer_p2.start()
+        else:
+            writer_p2 = None
 
         num_chunk_tasks = sum(isinstance(t, ChunkTask) for t in self.tasks)
         num_dl_tasks = len(self.chunks_to_dl)
@@ -909,8 +995,8 @@ class DLManager(Process):
         s_time = time.time()
         self.threads.append(Thread(target=self.chunk_signing_manager, args=(sig_chunks_cond,)))
         self.threads.append(Thread(target=self.download_job_manager, args=(task_cond, shm_cond, sig_chunks_cond)))
-        self.threads.append(Thread(target=self.dl_results_handler, args=(task_cond,)))
-        self.threads.append(Thread(target=self.fw_results_handler, args=(shm_cond,)))
+        self.threads.append(Thread(target=self.dl_results_handler, args=(task_cond, num_fw)))
+        self.threads.append(Thread(target=self.fw_results_handler, args=(shm_cond, num_fw)))
 
         for t in self.threads:
             t.start()
@@ -987,12 +1073,19 @@ class DLManager(Process):
 
         self.log.info('Waiting for installation to finish...')
         self.writer_queue.put_nowait(TerminateWorkerTask())
+        if num_fw > 1:
+            self.writer_queue_2.put_nowait(TerminateWorkerTask())
         self.signed_chunks_q.put_nowait((TerminateWorkerTask(), None))
 
         writer_p.join(timeout=10.0)
         if writer_p.exitcode is None:
-            self.log.warning(f'Terminating writer process, no exit code!')
+            self.log.warning('Terminating writer process 1, no exit code!')
             writer_p.terminate()
+        if writer_p2 is not None:
+            writer_p2.join(timeout=10.0)
+            if writer_p2.exitcode is None:
+                self.log.warning('Terminating writer process 2, no exit code!')
+                writer_p2.terminate()
 
         # forcibly kill DL workers that are not actually dead yet
         for child in self.children:

--- a/legendary/downloader/mp/manager.py
+++ b/legendary/downloader/mp/manager.py
@@ -574,8 +574,9 @@ class DLManager(Process):
                 self.log.debug(f'Adding {chunk.guid_num} (active: {self.active_tasks})')
                 try:
                     self.dl_worker_queue.put(DownloaderTask(url=url or (self.base_url + '/' + chunk.path),
-                                                            chunk_guid=chunk.guid_num, shm=sms),
-                                             timeout=1.0)
+                                                            chunk_guid=chunk.guid_num, shm=sms,
+                                                            compressed_size=chunk.file_size),
+                                                         timeout=1.0)
                 except Exception as e:
                     self.log.warning(f'Failed to add to download queue: {e!r}')
                     self.signed_chunks_q.put((chunk, url))

--- a/legendary/downloader/mp/manager.py
+++ b/legendary/downloader/mp/manager.py
@@ -908,21 +908,40 @@ class DLManager(Process):
             return 1
 
     def run_real(self):
-        # Cap shared memory against available system RAM before allocating.
-        # Never use more than 40 % of what the OS reports as free, but always
-        # keep at least enough for 2 chunks per worker so the pipeline can run.
         avail_ram = self._available_ram_bytes()
-        if avail_ram > 0:
-            ram_cap = int(avail_ram * 0.4)
-            min_shm = self.analysis.biggest_chunk * self.max_workers * 2
-            if self.max_shared_memory > ram_cap:
-                adjusted = max(ram_cap, min_shm)
-                self.log.info(
-                    f'Reducing shared memory {self.max_shared_memory // 1024 // 1024} MiB → '
-                    f'{adjusted // 1024 // 1024} MiB '
-                    f'(available RAM: {avail_ram // 1024 // 1024} MiB)'
-                )
-                self.max_shared_memory = adjusted
+
+        # Minimum SHM: enough for every worker to have 2 in-flight chunks, plus
+        # any reuse requirement computed by the manifest analysis.
+        min_shm = max(self.analysis.min_memory,
+                      self.analysis.biggest_chunk * self.max_workers * 2)
+
+        # Pipeline-optimal SHM: target_inflight is capped at max_workers*4.
+        # To sustain that rate, avail_shm/2 must stay >= max_workers*4, which
+        # requires total_segments >= max_workers*12.  Hard-cap at 512 MiB —
+        # no game pipeline benefits from more (SHM is demand-paged so larger
+        # allocations don't cost physical RAM until written).
+        pipeline_shm = max(min_shm, min(self.analysis.biggest_chunk * self.max_workers * 12,
+                                        512 * 1024 * 1024))
+
+        # Respect caller-supplied ceiling (--max-shared-memory) but don't exceed
+        # what the pipeline can use.
+        target = min(pipeline_shm, self.max_shared_memory)
+        target = max(target, min_shm)
+
+        # Safety cap for memory-constrained systems (< 8 GiB available).
+        # On ample-RAM systems the pipeline_shm target is already small enough.
+        if avail_ram > 0 and avail_ram < 8 * 1024 ** 3:
+            fraction = 0.20 if avail_ram < 4 * 1024 ** 3 else 0.30
+            ram_cap = max(min_shm, int(avail_ram * fraction))
+            target = min(target, ram_cap)
+
+        if target != self.max_shared_memory:
+            self.log.info(
+                f'Shared memory adjusted: {self.max_shared_memory // 1024 // 1024} MiB → '
+                f'{target // 1024 // 1024} MiB'
+                + (f' (RAM available: {avail_ram // 1024 // 1024} MiB)' if avail_ram > 0 else '')
+            )
+        self.max_shared_memory = target
 
         self.shared_memory = SharedMemory(create=True, size=self.max_shared_memory)
         self.log.debug(f'Created shared memory of size: {self.shared_memory.size / 1024 / 1024:.02f} MiB')
@@ -935,10 +954,15 @@ class DLManager(Process):
 
         self.log.debug(f'Created {len(self.sms)} shared memory segments.')
 
+        # Detect storage type early so writer_queue_2 is only created when needed.
+        num_fw = self._parallel_writers_for_path(self.dl_dir)
+        storage_label = 'SSD/NVMe' if num_fw > 1 else 'HDD or unknown'
+        self.log.info(f'Starting {num_fw} file writing worker(s) (storage detected: {storage_label})')
+
         # Create queues
         self.dl_worker_queue = MPQueue(-1)
         self.writer_queue = MPQueue(-1)
-        self.writer_queue_2 = MPQueue(-1)
+        self.writer_queue_2 = MPQueue(-1) if num_fw > 1 else None
         self.dl_result_q = MPQueue(-1)
         self.writer_result_q = MPQueue(-1)
         self.signed_chunks_q = MPQueue(-1)
@@ -955,10 +979,6 @@ class DLManager(Process):
                          dl_timeout=self.dl_timeout, bind_addr=bind_ip, secrets=self.manifest_secrets)
             self.children.append(w)
             w.start()
-
-        num_fw = self._parallel_writers_for_path(self.dl_dir)
-        storage_label = 'SSD/NVMe' if num_fw > 1 else 'HDD or unknown'
-        self.log.info(f'Starting {num_fw} file writing worker(s) (storage detected: {storage_label})')
 
         writer_p = FileWorker(self.writer_queue, self.writer_result_q, self.dl_dir,
                               self.shared_memory.name, self.cache_dir, self.logging_queue)

--- a/legendary/downloader/mp/manager.py
+++ b/legendary/downloader/mp/manager.py
@@ -131,16 +131,17 @@ class DLManager(Process):
                 mismatch = 0
                 completed_files = set()
 
-                for line in open(self.resume_file, encoding='utf-8').readlines():
-                    file_hash, _, filename = line.strip().partition(':')
-                    _p = os.path.join(self.dl_dir, filename)
-                    if not os.path.exists(_p):
-                        self.log.debug(f'File does not exist but is in resume file: "{_p}"')
-                        missing += 1
-                    elif file_hash != manifest.file_manifest_list.get_file_by_path(filename).sha_hash.hex():
-                        mismatch += 1
-                    else:
-                        completed_files.add(filename)
+                with open(self.resume_file, encoding='utf-8') as resume_f:
+                    for line in resume_f:
+                        file_hash, _, filename = line.strip().partition(':')
+                        _p = os.path.join(self.dl_dir, filename)
+                        if not os.path.exists(_p):
+                            self.log.debug(f'File does not exist but is in resume file: "{_p}"')
+                            missing += 1
+                        elif file_hash != manifest.file_manifest_list.get_file_by_path(filename).sha_hash.hex():
+                            mismatch += 1
+                        else:
+                            completed_files.add(filename)
 
                 if missing:
                     self.log.warning(f'{missing} previously completed file(s) are missing, they will be redownloaded.')
@@ -279,7 +280,7 @@ class DLManager(Process):
             # ignore files with less than N chunk parts, this speeds things up dramatically
             cp_threshold = 5
 
-            remaining_files = {fm.filename: {cp.guid_num for cp in fm.chunk_parts}
+            remaining_files = {fm.filename: (fm, {cp.guid_num for cp in fm.chunk_parts})
                                for fm in fmlist if fm.filename not in mc.unchanged}
             _fmlist = []
 
@@ -289,12 +290,12 @@ class DLManager(Process):
                     continue
 
                 _fmlist.append(fm)
-                f_chunks = remaining_files.pop(fm.filename)
+                _, f_chunks = remaining_files.pop(fm.filename)
                 if len(f_chunks) < cp_threshold:
                     continue
 
                 best_overlap, match = 0, None
-                for fname, chunks in remaining_files.items():
+                for fname, (_, chunks) in remaining_files.items():
                     if len(chunks) < cp_threshold:
                         continue
                     overlap = len(f_chunks & chunks)
@@ -302,8 +303,8 @@ class DLManager(Process):
                         best_overlap, match = overlap, fname
 
                 if match:
-                    _fmlist.append(manifest.file_manifest_list.get_file_by_path(match))
-                    remaining_files.pop(match)
+                    matched_fm, _ = remaining_files.pop(match)
+                    _fmlist.append(matched_fm)
 
             fmlist = _fmlist
             opt_delta = time.time() - s_time
@@ -421,14 +422,16 @@ class DLManager(Process):
             if reused:
                 self.log.debug(f' + Reusing {reused} chunks from: {current_file.filename}')
                 # open temporary file that will contain download + old file contents
-                self.tasks.append(FileTask(current_file.filename + u'.tmp', flags=TaskFlags.OPEN_FILE))
+                self.tasks.append(FileTask(current_file.filename + u'.tmp', flags=TaskFlags.OPEN_FILE,
+                                           file_size=current_file.file_size))
                 self.tasks.extend(chunk_tasks)
                 self.tasks.append(FileTask(current_file.filename + u'.tmp', flags=TaskFlags.CLOSE_FILE))
                 # delete old file and rename temporary
                 self.tasks.append(FileTask(current_file.filename, old_file=current_file.filename + u'.tmp',
                                            flags=TaskFlags.RENAME_FILE | TaskFlags.DELETE_FILE))
             else:
-                self.tasks.append(FileTask(current_file.filename, flags=TaskFlags.OPEN_FILE))
+                self.tasks.append(FileTask(current_file.filename, flags=TaskFlags.OPEN_FILE,
+                                           file_size=current_file.file_size))
                 self.tasks.extend(chunk_tasks)
                 self.tasks.append(FileTask(current_file.filename, flags=TaskFlags.CLOSE_FILE))
 
@@ -459,11 +462,11 @@ class DLManager(Process):
             raise MemoryError(f'Current shared memory cache is smaller than required: {shared_mib} < {required_mib}. '
                               + message)
 
-        # calculate actual dl and patch write size.
-        analysis_res.dl_size = \
-            sum(c.file_size for c in manifest.chunk_data_list.elements if c.guid_num in chunks_in_dl_list)
-        analysis_res.uncompressed_dl_size = \
-            sum(c.window_size for c in manifest.chunk_data_list.elements if c.guid_num in chunks_in_dl_list)
+        # calculate actual dl and patch write size in a single pass
+        for c in manifest.chunk_data_list.elements:
+            if c.guid_num in chunks_in_dl_list:
+                analysis_res.dl_size += c.file_size
+                analysis_res.uncompressed_dl_size += c.window_size
 
         # add jobs to remove files
         for fname in mc.removed:
@@ -490,7 +493,7 @@ class DLManager(Process):
         ticket = self._gen_ticket()
         while self.chunks_to_dl and self.running:
             if not self.signed_chunks_q.empty():
-                sleep(1)
+                sleep(0.05)
                 continue
 
             self.log.debug('Fetching more chunk URLs...')

--- a/legendary/downloader/mp/manager.py
+++ b/legendary/downloader/mp/manager.py
@@ -556,10 +556,12 @@ class DLManager(Process):
                 try:
                     chunk, url = self.signed_chunks_q.get(block=False)
                 except Empty:
+                    self.sms.appendleft(sms)
                     no_signed_chunks = True
                     break
 
                 if isinstance(chunk, TerminateWorkerTask):
+                    self.sms.appendleft(sms)
                     terminate = True
                     break
 
@@ -570,6 +572,7 @@ class DLManager(Process):
                                                          timeout=1.0)
                 except Exception as e:
                     self.log.warning(f'Failed to add to download queue: {e!r}')
+                    self.sms.appendleft(sms)
                     self.signed_chunks_q.put((chunk, url))
                     break
 

--- a/legendary/downloader/mp/workers.py
+++ b/legendary/downloader/mp/workers.py
@@ -306,17 +306,20 @@ class FileWorker(Process):
                     continue
                 elif j.flags & TaskFlags.CLOSE_FILE:
                     if current_file:
-                        # Release page cache for the completed file before closing so
-                        # the kernel doesn't keep written pages under memory pressure.
-                        if sys.platform == 'linux' and current_file_fd >= 0:
-                            try:
+                        # flush() moves the userspace buffer (up to 1 MiB) into the
+                        # kernel page cache first, so the subsequent DONTNEED hint
+                        # covers the entire file — not just what was already paged.
+                        # flush() is fast (no syscall round-trip to disk).
+                        try:
+                            current_file.flush()
+                            if sys.platform == 'linux' and current_file_fd >= 0:
                                 os.posix_fadvise(current_file_fd, 0, 0, os.POSIX_FADV_DONTNEED)
-                            except OSError:
-                                pass
-                        # Submit close to the background pool so btrfs CoW metadata
-                        # updates don't stall the write pipeline.  The file data is
-                        # already in the page cache; close() only flushes the userspace
-                        # buffer (fast) + triggers inode CoW (slow on btrfs).
+                        except OSError:
+                            pass
+                        # Submit the fd close to the background pool so btrfs inode
+                        # CoW (the slow part) doesn't stall the write pipeline.
+                        # flush() above already emptied the userspace buffer, so
+                        # close() here is just close(fd) + metadata update.
                         _close_pool.submit(current_file.close)
                         current_file = None
                         current_file_fd = -1

--- a/legendary/downloader/mp/workers.py
+++ b/legendary/downloader/mp/workers.py
@@ -37,6 +37,7 @@ def _fallocate_ok(path: str) -> bool:
     return _fs_type_cache[mount_dir] in _FALLOCATE_SUPPORTED_FS
 
 
+from concurrent.futures import ThreadPoolExecutor
 from logging.handlers import QueueHandler
 from multiprocessing import Process
 from multiprocessing.shared_memory import SharedMemory
@@ -242,8 +243,12 @@ class FileWorker(Process):
 
         last_filename = ''
         current_file = None
+        current_file_fd = -1  # raw fd for fadvise, kept until async close finishes
         # Cache directories we've already created to avoid a stat() per task.
         _dirs_created: set = set()
+        # Thread pool for async file closes so btrfs CoW metadata updates don't
+        # stall the write pipeline.  max_workers=2 handles a CLOSE/RENAME overlap.
+        _close_pool = ThreadPoolExecutor(max_workers=2, thread_name_prefix='fw-close')
 
         while True:
             try:
@@ -256,6 +261,8 @@ class FileWorker(Process):
                 if isinstance(j, TerminateWorkerTask):
                     if current_file:
                         current_file.close()
+                    # Wait for any in-flight async closes to finish before exiting
+                    _close_pool.shutdown(wait=True)
                     logger.debug('Worker received termination signal, shutting down...')
                     # send termination task to results halnder as well
                     self.o_q.put(TerminateWorkerTask())
@@ -281,16 +288,17 @@ class FileWorker(Process):
                         current_file.close()
 
                     current_file = open(full_path, 'wb', buffering=1024 * 1024)
+                    current_file_fd = current_file.fileno()
                     last_filename = j.filename
 
                     if sys.platform == 'linux':
                         if j.file_size > 0 and _fallocate_ok(full_path):
                             try:
-                                os.posix_fallocate(current_file.fileno(), 0, j.file_size)
+                                os.posix_fallocate(current_file_fd, 0, j.file_size)
                             except OSError as e:
                                 logger.debug(f'fallocate failed (not critical): {e}')
                         try:
-                            os.posix_fadvise(current_file.fileno(), 0, 0, os.POSIX_FADV_NOREUSE)
+                            os.posix_fadvise(current_file_fd, 0, 0, os.POSIX_FADV_NOREUSE)
                         except OSError:
                             pass
 
@@ -298,8 +306,20 @@ class FileWorker(Process):
                     continue
                 elif j.flags & TaskFlags.CLOSE_FILE:
                     if current_file:
-                        current_file.close()
+                        # Release page cache for the completed file before closing so
+                        # the kernel doesn't keep written pages under memory pressure.
+                        if sys.platform == 'linux' and current_file_fd >= 0:
+                            try:
+                                os.posix_fadvise(current_file_fd, 0, 0, os.POSIX_FADV_DONTNEED)
+                            except OSError:
+                                pass
+                        # Submit close to the background pool so btrfs CoW metadata
+                        # updates don't stall the write pipeline.  The file data is
+                        # already in the page cache; close() only flushes the userspace
+                        # buffer (fast) + triggers inode CoW (slow on btrfs).
+                        _close_pool.submit(current_file.close)
                         current_file = None
+                        current_file_fd = -1
                     else:
                         logger.warning(f'Asking to close file that is not open: {j.filename}')
 

--- a/legendary/downloader/mp/workers.py
+++ b/legendary/downloader/mp/workers.py
@@ -1,8 +1,41 @@
 # coding: utf-8
 
 import os
+import sys
 import time
 import logging
+
+# Filesystems where posix_fallocate works natively (no fallback to zeroing).
+# btrfs and zfs lack kernel-level fallocate support and fall back to writing
+# zeros for every file, doubling I/O — so they are intentionally excluded.
+_FALLOCATE_SUPPORTED_FS = frozenset({'ext4', 'ext3', 'ext2', 'xfs', 'f2fs', 'tmpfs'})
+_fs_type_cache: dict = {}
+
+
+def _fs_type_for_path(path: str) -> str:
+    """Return the filesystem type (e.g. 'ext4', 'btrfs') for *path* via /proc/mounts."""
+    try:
+        real = os.path.realpath(path)
+        best_mount, best_type = '', ''
+        with open('/proc/mounts') as f:
+            for line in f:
+                parts = line.split()
+                if len(parts) >= 3:
+                    mp, fst = parts[1], parts[2]
+                    if real.startswith(mp) and len(mp) > len(best_mount):
+                        best_mount, best_type = mp, fst
+        return best_type
+    except Exception:
+        return ''
+
+
+def _fallocate_ok(path: str) -> bool:
+    """Return True if posix_fallocate is safe to use on the filesystem hosting *path*."""
+    mount_dir = os.path.dirname(path)
+    if mount_dir not in _fs_type_cache:
+        _fs_type_cache[mount_dir] = _fs_type_for_path(mount_dir)
+    return _fs_type_cache[mount_dir] in _FALLOCATE_SUPPORTED_FS
+
 
 from logging.handlers import QueueHandler
 from multiprocessing import Process
@@ -81,19 +114,17 @@ class DLWorker(Process):
                 logger.debug('Worker received termination signal, shutting down...')
                 break
 
-            tries = 0
             compressed = 0
             chunk = None
 
             try:
-                while tries < self.max_retries:
+                for tries in range(self.max_retries):
                     # retry once immediately, otherwise do exponential backoff
                     if tries > 1:
                         sleep_time = 2**(tries-1)
                         logger.info(f'Sleeping {sleep_time} seconds before retrying.')
                         time.sleep(sleep_time)
 
-                    # print('Downloading', job.url)
                     logger.debug(f'Downloading {job.url}')
 
                     try:
@@ -103,13 +134,9 @@ class DLWorker(Process):
                         logger.warning(f'Chunk download for {job.chunk_guid} failed: ({e!r}), retrying...')
                         continue
 
-                    if r.status_code != 200:
-                        logger.warning(f'Chunk download for {job.chunk_guid} failed: status {r.status_code}, retrying...')
-                        continue
-                    else:
-                        compressed = len(r.content)
-                        chunk = Chunk.read_buffer(r.content, self.secrets)
-                        break
+                    compressed = len(r.content)
+                    chunk = Chunk.read_buffer(r.content, self.secrets)
+                    break
                 else:
                     raise TimeoutError('Max retries reached')
             except Exception as e:
@@ -203,8 +230,19 @@ class FileWorker(Process):
                         logger.warning(f'Opening new file {j.filename} without closing previous! {last_filename}')
                         current_file.close()
 
-                    current_file = open(full_path, 'wb')
+                    current_file = open(full_path, 'wb', buffering=1024 * 1024)
                     last_filename = j.filename
+
+                    if sys.platform == 'linux':
+                        if j.file_size > 0 and _fallocate_ok(full_path):
+                            try:
+                                os.posix_fallocate(current_file.fileno(), 0, j.file_size)
+                            except OSError as e:
+                                logger.debug(f'fallocate failed (not critical): {e}')
+                        try:
+                            os.posix_fadvise(current_file.fileno(), 0, 0, os.POSIX_FADV_NOREUSE)
+                        except OSError:
+                            pass
 
                     self.o_q.put(WriterTaskResult(success=True, **j.__dict__))
                     continue
@@ -273,7 +311,7 @@ class FileWorker(Process):
                     if j.shared_memory:
                         shm_offset = j.shared_memory.offset + j.chunk_offset
                         shm_end = shm_offset + j.chunk_size
-                        current_file.write(self.shm.buf[shm_offset:shm_end])
+                        current_file.write(memoryview(self.shm.buf)[shm_offset:shm_end])
                     elif j.cache_file:
                         with open(os.path.join(self.cache_path, j.cache_file), 'rb') as f:
                             if j.chunk_offset:
@@ -281,6 +319,11 @@ class FileWorker(Process):
                             current_file.write(f.read(j.chunk_size))
                     elif j.old_file:
                         with open(os.path.join(self.base_path, j.old_file), 'rb') as f:
+                            if sys.platform == 'linux':
+                                try:
+                                    os.posix_fadvise(f.fileno(), 0, 0, os.POSIX_FADV_SEQUENTIAL)
+                                except OSError:
+                                    pass
                             if j.chunk_offset:
                                 f.seek(j.chunk_offset)
                             current_file.write(f.read(j.chunk_size))

--- a/legendary/downloader/mp/workers.py
+++ b/legendary/downloader/mp/workers.py
@@ -197,6 +197,8 @@ class FileWorker(Process):
 
         last_filename = ''
         current_file = None
+        # Cache directories we've already created to avoid a stat() per task.
+        _dirs_created: set = set()
 
         while True:
             try:
@@ -214,18 +216,21 @@ class FileWorker(Process):
                     self.o_q.put(TerminateWorkerTask())
                     break
 
-                # make directories if required
-                path = os.path.split(j.filename)[0]
-                if not os.path.exists(os.path.join(self.base_path, path)):
-                    os.makedirs(os.path.join(self.base_path, path))
-
                 full_path = os.path.join(self.base_path, j.filename)
 
                 if j.flags & TaskFlags.CREATE_EMPTY_FILE:  # just create an empty file
+                    dir_path = os.path.join(self.base_path, os.path.split(j.filename)[0])
+                    if dir_path not in _dirs_created:
+                        os.makedirs(dir_path, exist_ok=True)
+                        _dirs_created.add(dir_path)
                     open(full_path, 'a').close()
                     self.o_q.put(WriterTaskResult(success=True, **j.__dict__))
                     continue
                 elif j.flags & TaskFlags.OPEN_FILE:
+                    dir_path = os.path.join(self.base_path, os.path.split(j.filename)[0])
+                    if dir_path not in _dirs_created:
+                        os.makedirs(dir_path, exist_ok=True)
+                        _dirs_created.add(dir_path)
                     if current_file:
                         logger.warning(f'Opening new file {j.filename} without closing previous! {last_filename}')
                         current_file.close()

--- a/legendary/downloader/mp/workers.py
+++ b/legendary/downloader/mp/workers.py
@@ -41,6 +41,7 @@ from logging.handlers import QueueHandler
 from multiprocessing import Process
 from multiprocessing.shared_memory import SharedMemory
 from queue import Empty
+from threading import Thread
 
 import requests
 from requests.adapters import HTTPAdapter, DEFAULT_POOLBLOCK
@@ -89,6 +90,43 @@ class DLWorker(Process):
             self.session.mount('https://', adapter)
             self.session.mount('http://', adapter)
 
+        # Per-worker flag: set to False the first time a range request fails,
+        # disabling splits for the rest of this worker's lifetime.
+        self._ranges_ok = True
+
+    def _ranged_download(self, url: str, total: int):
+        """
+        Download *url* as two parallel half-range requests.
+        Returns the assembled bytes, or None if ranges are unsupported or failed.
+        Each half uses its own TCP connection → bypasses per-connection CDN throttling.
+        """
+        mid = total // 2
+        parts = [None, None]
+        ok = [True, True]
+
+        def fetch(idx, start, end):
+            try:
+                r = self.session.get(url, timeout=self.dl_timeout,
+                                     headers={'Range': f'bytes={start}-{end}'})
+                if r.status_code == 206:
+                    parts[idx] = r.content
+                else:
+                    ok[idx] = False
+            except Exception:
+                ok[idx] = False
+
+        t0 = Thread(target=fetch, args=(0, 0, mid - 1), daemon=True)
+        t1 = Thread(target=fetch, args=(1, mid, total - 1), daemon=True)
+        t0.start()
+        t1.start()
+        t0.join(timeout=self.dl_timeout + 5)
+        t1.join(timeout=self.dl_timeout + 5)
+
+        if not all(ok) or None in parts:
+            self._ranges_ok = False
+            return None
+        return parts[0] + parts[1]
+
     def run(self):
         # we have to fix up the logger before we can start
         _root = logging.getLogger()
@@ -128,14 +166,21 @@ class DLWorker(Process):
                     logger.debug(f'Downloading {job.url}')
 
                     try:
-                        r = self.session.get(job.url, timeout=self.dl_timeout)
-                        r.raise_for_status()
+                        raw = None
+                        # Split into 2 parallel range requests when CDN supports it
+                        # and chunk is large enough to benefit (≥ 256 KiB compressed).
+                        if self._ranges_ok and job.compressed_size >= 256 * 1024:
+                            raw = self._ranged_download(job.url, job.compressed_size)
+                        if raw is None:
+                            r = self.session.get(job.url, timeout=self.dl_timeout)
+                            r.raise_for_status()
+                            raw = r.content
                     except Exception as e:
                         logger.warning(f'Chunk download for {job.chunk_guid} failed: ({e!r}), retrying...')
                         continue
 
-                    compressed = len(r.content)
-                    chunk = Chunk.read_buffer(r.content, self.secrets)
+                    compressed = len(raw)
+                    chunk = Chunk.read_buffer(raw, self.secrets)
                     break
                 else:
                     raise TimeoutError('Max retries reached')

--- a/legendary/downloader/mp/workers.py
+++ b/legendary/downloader/mp/workers.py
@@ -37,12 +37,10 @@ def _fallocate_ok(path: str) -> bool:
     return _fs_type_cache[mount_dir] in _FALLOCATE_SUPPORTED_FS
 
 
-from concurrent.futures import ThreadPoolExecutor
 from logging.handlers import QueueHandler
 from multiprocessing import Process
 from multiprocessing.shared_memory import SharedMemory
 from queue import Empty
-from threading import Thread
 
 import requests
 from requests.adapters import HTTPAdapter, DEFAULT_POOLBLOCK
@@ -91,43 +89,6 @@ class DLWorker(Process):
             self.session.mount('https://', adapter)
             self.session.mount('http://', adapter)
 
-        # Per-worker flag: set to False the first time a range request fails,
-        # disabling splits for the rest of this worker's lifetime.
-        self._ranges_ok = True
-
-    def _ranged_download(self, url: str, total: int):
-        """
-        Download *url* as two parallel half-range requests.
-        Returns the assembled bytes, or None if ranges are unsupported or failed.
-        Each half uses its own TCP connection → bypasses per-connection CDN throttling.
-        """
-        mid = total // 2
-        parts = [None, None]
-        ok = [True, True]
-
-        def fetch(idx, start, end):
-            try:
-                r = self.session.get(url, timeout=self.dl_timeout,
-                                     headers={'Range': f'bytes={start}-{end}'})
-                if r.status_code == 206:
-                    parts[idx] = r.content
-                else:
-                    ok[idx] = False
-            except Exception:
-                ok[idx] = False
-
-        t0 = Thread(target=fetch, args=(0, 0, mid - 1), daemon=True)
-        t1 = Thread(target=fetch, args=(1, mid, total - 1), daemon=True)
-        t0.start()
-        t1.start()
-        t0.join(timeout=self.dl_timeout + 5)
-        t1.join(timeout=self.dl_timeout + 5)
-
-        if not all(ok) or None in parts:
-            self._ranges_ok = False
-            return None
-        return parts[0] + parts[1]
-
     def run(self):
         # we have to fix up the logger before we can start
         _root = logging.getLogger()
@@ -167,15 +128,9 @@ class DLWorker(Process):
                     logger.debug(f'Downloading {job.url}')
 
                     try:
-                        raw = None
-                        # Split into 2 parallel range requests when CDN supports it
-                        # and chunk is large enough to benefit (≥ 256 KiB compressed).
-                        if self._ranges_ok and job.compressed_size >= 256 * 1024:
-                            raw = self._ranged_download(job.url, job.compressed_size)
-                        if raw is None:
-                            r = self.session.get(job.url, timeout=self.dl_timeout)
-                            r.raise_for_status()
-                            raw = r.content
+                        r = self.session.get(job.url, timeout=self.dl_timeout)
+                        r.raise_for_status()
+                        raw = r.content
                     except Exception as e:
                         logger.warning(f'Chunk download for {job.chunk_guid} failed: ({e!r}), retrying...')
                         continue
@@ -243,12 +198,9 @@ class FileWorker(Process):
 
         last_filename = ''
         current_file = None
-        current_file_fd = -1  # raw fd for fadvise, kept until async close finishes
+        current_file_fd = -1
         # Cache directories we've already created to avoid a stat() per task.
         _dirs_created: set = set()
-        # Thread pool for async file closes so btrfs CoW metadata updates don't
-        # stall the write pipeline.  max_workers=2 handles a CLOSE/RENAME overlap.
-        _close_pool = ThreadPoolExecutor(max_workers=2, thread_name_prefix='fw-close')
 
         while True:
             try:
@@ -261,8 +213,6 @@ class FileWorker(Process):
                 if isinstance(j, TerminateWorkerTask):
                     if current_file:
                         current_file.close()
-                    # Wait for any in-flight async closes to finish before exiting
-                    _close_pool.shutdown(wait=True)
                     logger.debug('Worker received termination signal, shutting down...')
                     # send termination task to results halnder as well
                     self.o_q.put(TerminateWorkerTask())
@@ -287,7 +237,7 @@ class FileWorker(Process):
                         logger.warning(f'Opening new file {j.filename} without closing previous! {last_filename}')
                         current_file.close()
 
-                    current_file = open(full_path, 'wb', buffering=1024 * 1024)
+                    current_file = open(full_path, 'wb')
                     current_file_fd = current_file.fileno()
                     last_filename = j.filename
 
@@ -297,21 +247,12 @@ class FileWorker(Process):
                                 os.posix_fallocate(current_file_fd, 0, j.file_size)
                             except OSError as e:
                                 logger.debug(f'fallocate failed (not critical): {e}')
-                        try:
-                            os.posix_fadvise(current_file_fd, 0, 0, os.POSIX_FADV_NOREUSE)
-                        except OSError:
-                            pass
 
                     self.o_q.put(WriterTaskResult(success=True, **j.__dict__))
                     continue
                 elif j.flags & TaskFlags.CLOSE_FILE:
                     if current_file:
-                        # Submit close to the background pool so btrfs inode CoW
-                        # (the slow part) doesn't stall the write pipeline.
-                        # NOTE: FADV_DONTNEED was removed — on btrfs it forces
-                        # immediate writeback of dirty pages, breaking write
-                        # coalescing and causing oscillating disk I/O.
-                        _close_pool.submit(current_file.close)
+                        current_file.close()
                         current_file = None
                         current_file_fd = -1
                     else:

--- a/legendary/downloader/mp/workers.py
+++ b/legendary/downloader/mp/workers.py
@@ -306,20 +306,11 @@ class FileWorker(Process):
                     continue
                 elif j.flags & TaskFlags.CLOSE_FILE:
                     if current_file:
-                        # flush() moves the userspace buffer (up to 1 MiB) into the
-                        # kernel page cache first, so the subsequent DONTNEED hint
-                        # covers the entire file — not just what was already paged.
-                        # flush() is fast (no syscall round-trip to disk).
-                        try:
-                            current_file.flush()
-                            if sys.platform == 'linux' and current_file_fd >= 0:
-                                os.posix_fadvise(current_file_fd, 0, 0, os.POSIX_FADV_DONTNEED)
-                        except OSError:
-                            pass
-                        # Submit the fd close to the background pool so btrfs inode
-                        # CoW (the slow part) doesn't stall the write pipeline.
-                        # flush() above already emptied the userspace buffer, so
-                        # close() here is just close(fd) + metadata update.
+                        # Submit close to the background pool so btrfs inode CoW
+                        # (the slow part) doesn't stall the write pipeline.
+                        # NOTE: FADV_DONTNEED was removed — on btrfs it forces
+                        # immediate writeback of dirty pages, breaking write
+                        # coalescing and causing oscillating disk I/O.
                         _close_pool.submit(current_file.close)
                         current_file = None
                         current_file_fd = -1

--- a/legendary/models/downloading.py
+++ b/legendary/models/downloading.py
@@ -29,6 +29,7 @@ class DownloaderTask:
     url: str
     chunk_guid: int
     shm: SharedMemorySegment
+    compressed_size: int = 0  # compressed chunk size from manifest (enables range splitting)
 
 
 @dataclass
@@ -36,7 +37,7 @@ class DownloaderTaskResult(DownloaderTask):
     """
     Result of DownloaderTask provided by download workers
     """
-    success: bool
+    success: bool = False
     size_downloaded: Optional[int] = None
     size_decompressed: Optional[int] = None
 

--- a/legendary/models/downloading.py
+++ b/legendary/models/downloading.py
@@ -29,7 +29,6 @@ class DownloaderTask:
     url: str
     chunk_guid: int
     shm: SharedMemorySegment
-    compressed_size: int = 0  # compressed chunk size from manifest (enables range splitting)
 
 
 @dataclass

--- a/legendary/models/downloading.py
+++ b/legendary/models/downloading.py
@@ -76,6 +76,7 @@ class FileTask:
     flags: TaskFlags
     # If rename is true, this is the name of the file to be renamed
     old_file: Optional[str] = None
+    file_size: int = 0
 
 
 @dataclass
@@ -96,6 +97,7 @@ class WriterTask:
     # File to read old chunk from, disk chunk cache or old game file
     old_file: Optional[str] = None
     cache_file: Optional[str] = None
+    file_size: int = 0
 
 
 @dataclass


### PR DESCRIPTION
When a download chunk fails, the shared memory segment (sms) was being popped from the pool but never returned to it on error paths.
self.sms is a deque acting as a pool of available shared memory slots. The normal flow correctly returns slots via self.sms.appendleft(sms) after a chunk is processed, but error paths were missing this call.
With enough failed chunks, the pool would reach 0 available slots. download_job_manager would then wait on shm_cond for a slot to be freed, but since no chunks were in-flight, nothing would ever free one — causing a permanent deadlock.
This explains the hung installations reported by some users, with no error message and no progress.

Fix: Add self.sms.appendleft(sms) in the 3 error paths where the segment was being lost