### PR TITLE
manager.py: Return shared memory segments to pool on error paths

### DIFF
--- a/legendary/downloader/mp/manager.py
+++ b/legendary/downloader/mp/manager.py
@@ -535,10 +535,12 @@ class DLManager(Process):
                 try:
                     chunk, url = self.signed_chunks_q.get(False, 3.0)
                 except Empty:
+                    self.sms.appendleft(sms)
                     no_signed_chunks = True
                     break
 
                 if isinstance(chunk, TerminateWorkerTask):
+                    self.sms.appendleft(sms)
                     terminate = True
                     break
 
@@ -549,6 +551,7 @@ class DLManager(Process):
                                              timeout=1.0)
                 except Exception as e:
                     self.log.warning(f'Failed to add to download queue: {e!r}')
+                    self.sms.appendleft(sms)
                     self.signed_chunks_q.put((chunk, url))
                     break
 


### PR DESCRIPTION
When a download chunk fails, the shared memory segment (sms) was being popped from the pool but never returned to it on error paths.
self.sms is a deque acting as a pool of available shared memory slots. The normal flow correctly returns slots via self.sms.appendleft(sms) after a chunk is processed, but error paths were missing this call.
With enough failed chunks, the pool would reach 0 available slots. download_job_manager would then wait on shm_cond for a slot to be freed, but since no chunks were in-flight, nothing would ever free one — causing a permanent deadlock.
This explains the hung installations reported by some users, with no error message and no progress.
Fix: Add self.sms.appendleft(sms) in the 3 error paths where the segment was being lost