### PR TITLE
manager.py: Path without signed URLs never notifies sig_chunks_cond

### DIFF
--- a/legendary/downloader/mp/manager.py
+++ b/legendary/downloader/mp/manager.py
@@ -484,6 +484,8 @@ class DLManager(Process):
         # If we're not using signed URLs, just pretend the raw chunks are the signed ones
         for guid in self.chunks_to_dl:
             self.signed_chunks_q.put((self.chunk_data_list.get_chunk_by_guid(guid), None))
+            with sig_chunks_cond:
+                sig_chunks_cond.notify()
 
 
     def _do_chunk_signing(self, sig_chunks_cond: Condition):


### PR DESCRIPTION
In chunk_signing_manager, the path that handles signed URLs correctly calls sig_chunks_cond.notify() after each chunk added to the queue via _do_chunk_signing. However, the fallback path for non-signed URLs fills the queue in a tight loop without ever notifying sig_chunks_cond.
If download_job_manager starts and finds the queue empty before chunk_signing_manager has finished filling it (scheduling race between threads), it will wait up to 1 second unnecessarily before retrying.
Fix: Add sig_chunks_cond.notify() after each chunk put in the non-signed path, making it consistent with _do_chunk_signing.