### PR TITLE
manager.py: Fix shutdown signaling and tight retry loop in download job manager

### DIFF
--- a/legendary/downloader/mp/manager.py
+++ b/legendary/downloader/mp/manager.py
@@ -539,6 +539,7 @@ class DLManager(Process):
                     break
 
                 if isinstance(chunk, TerminateWorkerTask):
+                    self.running = False
                     terminate = True
                     break
 
@@ -550,6 +551,7 @@ class DLManager(Process):
                 except Exception as e:
                     self.log.warning(f'Failed to add to download queue: {e!r}')
                     self.signed_chunks_q.put((chunk, url))
+                    no_signed_chunks = True
                     break
 
                 self.active_tasks += 1

--- a/legendary/downloader/mp/manager.py
+++ b/legendary/downloader/mp/manager.py
@@ -504,6 +504,11 @@ class DLManager(Process):
 
             self.sign_pipe.send((ticket.signedTicket, list(c.path for c in unprocessed_chunks)))
 
+            while self.running and not self.sign_pipe.poll(1.0):
+                pass
+            if not self.running:
+                return
+
             signed_urls: dict[str, str] = self.sign_pipe.recv()
             for chunk in unprocessed_chunks:
                 signed_url = signed_urls[chunk.path]


### PR DESCRIPTION

Three related fixes to download_job_manager and _do_chunk_signing:

1. Set self.running = False on TerminateWorkerTask

When download_job_manager receives a TerminateWorkerTask, it now sets self.running = False before breaking. This signals _do_chunk_signing to exit its loop cleanly instead of continuing to process chunks for a download that's already terminating.

2. Make _do_chunk_signing interruptible on sign_pipe.recv()

Previously, sign_pipe.recv() could block indefinitely even after self.running was set to False. Replaced with a poll(1.0) loop that checks self.running on each iteration, so the thread exits cleanly within ≤1 second of receiving the terminate signal.

The poll(1.0) loop is not busy-wait — it blocks at the OS level until data arrives or the timeout expires. In the normal case the signing response arrives in milliseconds and the loop never iterates more than once. The only case where multiple iterations occur is during shutdown, where ≤1 second of latency is acceptable. A shorter timeout would only add more iterations with no benefit.
3. Set no_signed_chunks = True in the exception handler

When dl_worker_queue.put() raises an exception, the outer loop now waits before retrying instead of spinning in a tight retry loop.