### PR TITLE
manager.py: Remove dead timeout argument from non-blocking queue.get() call

### DIFF
--- a/legendary/downloader/mp/manager.py
+++ b/legendary/downloader/mp/manager.py
@@ -533,7 +533,7 @@ class DLManager(Process):
                     break
 
                 try:
-                    chunk, url = self.signed_chunks_q.get(False, 3.0)
+                    chunk, url = self.signed_chunks_q.get(block=False)
                 except Empty:
                     no_signed_chunks = True
                     break


### PR DESCRIPTION
self.signed_chunks_q.get(False, 3.0) passes block=False, which makes the timeout=3.0 argument dead code — Python's Queue.get() ignores the timeout when blocking is disabled.
Replaced with self.signed_chunks_q.get(block=False) using an explicit keyword argument, which makes the non-blocking intent clear and removes the misleading timeout value.
No behavior change.