### PR TITLE
manager.py: Fix unchanged field being corrupted with file size bytes

### DIFF
--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -1055,7 +1055,7 @@ class LegendaryCLI:
         logger.info(f'Download size: {analysis.dl_size / 1024 / 1024:.02f} MiB '
                     f'(Compression savings: {compression:.01f}%)')
         logger.info(f'Reusable size: {analysis.reuse_size / 1024 / 1024:.02f} MiB (chunks) / '
-                    f'{analysis.unchanged / 1024 / 1024:.02f} MiB (unchanged / skipped)')
+                    f'{analysis.unchanged_size / 1024 / 1024:.02f} MiB (unchanged / skipped)')
         logger.info('Downloads are resumable, you can interrupt the download with '
                     'CTRL-C and resume it using the same command later on.')
 

--- a/legendary/downloader/mp/manager.py
+++ b/legendary/downloader/mp/manager.py
@@ -251,7 +251,7 @@ class DLManager(Process):
 
             # chunks of unchanged files are not downloaded so we can skip them
             if fm.filename in mc.unchanged:
-                analysis_res.unchanged += fm.file_size
+                analysis_res.unchanged_size += fm.file_size
                 continue
 
             for cp in fm.chunk_parts:


### PR DESCRIPTION
AnalysisResult defines two separate fields:

unchanged: int — count of unchanged files
unchanged_size: int — total size in bytes of unchanged files

In manager.py, line 254 was writing file sizes into unchanged instead of unchanged_size:
python# Before (incorrect)
analysis_res.unchanged += fm.file_size  # mixes byte values into a file count

# After
analysis_res.unchanged_size += fm.file_size
This meant any code reading analysis_res.unchanged would get a completely corrupt value (file count + accumulated bytes), and unchanged_size was always left at 0 despite being declared in the dataclass.