### PR TITLE
Failure when resuming download using Legendary

### DIFF
--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -1024,6 +1024,11 @@ class LegendaryCLI:
         if not analysis.dl_size:
             old_igame = self.core.get_installed_game(game.app_name)
             logger.info('Download size is 0, the game is either already up to date or has not changed. Exiting...')
+            # Files are fully present on disk but game was never registered (e.g. interrupted install)
+            if not old_igame and not args.no_install:
+                logger.info('Game files are complete but installation was not registered, registering now...')
+                self.core.install_game(igame)
+                old_igame = igame
             if old_igame and args.repair_mode and os.path.exists(repair_file):
                 if old_igame.needs_verification:
                     old_igame.needs_verification = False

--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -1039,7 +1039,7 @@ class LegendaryCLI:
                 self.core.uninstall_tag(old_igame)
                 self.core.install_game(old_igame)
 
-            if old_igame.install_tags:
+            if old_igame and old_igame.install_tags:
                 self.core.lgd.config.set(game.app_name, 'install_tags', ','.join(old_igame.install_tags))
                 self.core.lgd.save_config()
 


### PR DESCRIPTION
heroic issue 5654 

Describe the bug

When resuming a previously interrupted fresh install, if legendary determines
the download size is 0 (nothing new to fetch), it crashes with:

AttributeError: 'NoneType' object has no attribute 'install_tags'

This happens because old_igame is None for games not yet in the installed
library, but the code accesses it unconditionally.

#logs
```
¡Se ha producido un error! Intente cerrar sesión e iniciar sesión nuevamente en su cuenta de Epic.
[Core] INFO: Trying to re-use existing login session...[cli] INFO: Preparing download for "3 out of 10, EP 2: "Foundation 101"" (1317e4e3b3ed40c289dde85b194347d3)...[Core] INFO: Parsing game manifest...[Core] INFO: Install path: /home/paraguayo33/Games/Heroic/threeoutof10Ep2[Core] INFO: Selected CDN: egdownload.fastly-edge.com (http)[DLM] INFO: Found previously interrupted download. Download will be resumed if possible.[DLM] INFO: Skipping 25 files based on resume data.[cli] INFO: Download size is 0, the game is either already up to date or has not changed. Exiting...Traceback (most recent call last):File "<frozen runpy>", line 203, in _run_module_as_main
File "<frozen runpy>", line 88, in _run_code
File "/opt/Heroic/resources/app.asar.unpacked/build/bin/x64/linux/./legendary/__main__.py", line 40, in <module>
legendary.cli.main()
~~~~~~~~~~~~~~~~~~^^
File "/opt/Heroic/resources/app.asar.unpacked/build/bin/x64/linux/./legendary/legendary/cli.py", line 3264, in main
cli.install_game(args)
~~~~~~~~~~~~~~~~^^^^^^
File "/opt/Heroic/resources/app.asar.unpacked/build/bin/x64/linux/./legendary/legendary/cli.py", line 1042, in install_game
if old_igame.install_tags:
^^^^^^^^^^^^^^^^^^^^^^AttributeError: 'NoneType' object has no attribute 'install_tags'
```